### PR TITLE
[feat] 알림 모달 UI 컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env.development
+
 # Logs
 logs
 *.log

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" data-theme="oz_dark">
   <head>
     <meta charset="UTF-8" />

--- a/src/components/Notice/NoticeCard.tsx
+++ b/src/components/Notice/NoticeCard.tsx
@@ -1,6 +1,7 @@
 import type { Notification } from "./notice.types";
 import { toMdHm } from "./format";
 import { buildNoticeCopy } from "./copy";
+import { useTheme } from "./useTheme";
 
 export default function NoticeCard({
   n,
@@ -9,11 +10,14 @@ export default function NoticeCard({
   n: Notification;
   deleteMode: boolean;
 }) {
+  const { isDark } = useTheme();
+
   const { snippet, suffix } = buildNoticeCopy(n);
   const detail = n.detail ?? "";
   const time = toMdHm(n.createdAt);
   const path = n.context?.path;
   const clickable = !deleteMode; // 삭제모드 아닐 때만 인터랙션
+  const isSystem = n.type === "system"; // 공지(system) 구분
   const isQuoted = n.type !== "system"; // comment/reply만 따옴표
 
   // 툴팁 원문
@@ -24,27 +28,58 @@ export default function NoticeCard({
         ? n.context?.myComment
         : (n.text ?? "");
 
+  const normalUnreadBg = isDark ? "bg-base-300" : "bg-base-200";
+  const normalReadBg = "bg-base-200";
+  const baseBgClass = isSystem
+    ? n.read
+      ? "bg-info/5  border-info/30"
+      : "bg-info/10 border-info/50"
+    : n.read
+      ? `${normalReadBg} border-base-300`
+      : `${normalUnreadBg} border-base-300`;
+
+  const hoverOverlayClass = clickable
+    ? isSystem
+      ? "group-hover:bg-info/10"
+      : isDark
+        ? "group-hover:bg-white/5" // 다크에선 밝은 오버레이
+        : "group-hover:bg-black/5" // 라이트에선 어두운 오버레이
+    : "";
+
+  // 그림자: 읽음은 없음, 안 읽음만 hover 시 살짝 업(강도 낮게)
+  const elevationBase = n.read ? "shadow-none" : "shadow-md";
+  const elevationHover = !n.read && clickable ? "hover:shadow-md" : "";
+
   return (
     <article
       role={clickable ? (path ? "link" : "button") : undefined}
       tabIndex={clickable ? 0 : undefined}
       className={[
-        "relative rounded-xl border p-3 md:p-4 transition-colors",
-        n.read
-          ? "bg-base-300 border-base-300 text-neutral-content"
-          : "bg-base-200 border-base-300",
-        clickable ? "cursor-pointer hover:bg-base-100/40" : "cursor-default",
+        "relative group overflow-hidden rounded-xl border p-3 md:p-4 transition-all",
+        baseBgClass,
+        elevationBase,
+        elevationHover,
+        clickable ? "cursor-pointer" : "cursor-default",
       ].join(" ")}
       // TODO: UI만 작업함, 실제 이동/읽음 로직은 후속 이슈에서 연결
       onClick={undefined}
       title={rawForTitle || undefined}
     >
+      {/* 배경 오버레이: hover 시에만 살짝 보임 (텍스트에는 영향 없음) */}
+      <span
+        aria-hidden
+        className={[
+          "pointer-events-none absolute inset-0 rounded-xl transition-colors z-[0]",
+          hoverOverlayClass || "bg-transparent",
+        ].join(" ")}
+      />
+
       {/* 삭제모드: 우상단 X */}
       {deleteMode && (
         <button
           type="button"
           aria-label="알림 삭제"
-          className="absolute right-2 top-2 w-6 h-6 rounded-full flex items-center justify-center opacity-90 hover:opacity-100"
+          className="absolute right-2 top-2 w-6 h-6 rounded-full flex items-center justify-center opacity-90 hover:opacity-100 z-[1]"
         >
           <span className="text-base text-primary-content leading-none">×</span>
         </button>
@@ -54,12 +89,12 @@ export default function NoticeCard({
       {!n.read && !deleteMode && (
         <i
           aria-hidden
-          className="absolute right-3 top-3 inline-block w-2 h-2 rounded-full bg-error"
+          className="absolute right-3 top-3 inline-block w-2 h-2 rounded-full bg-error z-[1]"
         />
       )}
 
       {/* 내용 영역 */}
-      <div className="flex items-start gap-2 pr-8">
+      <div className="flex items-start gap-2 pr-8 relative z-[1]">
         <div className="min-w-0 w-full">
           {/* 1) 첫째 줄: “ + snippet(길어지면 … 처리) + ” + suffix(항상 보임) */}
           <div className="flex items-baseline whitespace-nowrap overflow-hidden text-xs md:text-sm text-neutral-content">

--- a/src/components/Notice/NoticeCard.tsx
+++ b/src/components/Notice/NoticeCard.tsx
@@ -9,31 +9,48 @@ export default function NoticeCard({
   n: Notification;
   deleteMode: boolean;
 }) {
-  const copy = buildNoticeCopy(n);
+  const { snippet, suffix } = buildNoticeCopy(n);
   const detail = n.detail ?? "";
   const time = toMdHm(n.createdAt);
+  const path = n.context?.path;
+  const clickable = !deleteMode; // 삭제모드 아닐 때만 인터랙션
+  const isQuoted = n.type !== "system"; // comment/reply만 따옴표
+
+  // 툴팁 원문
+  const rawForTitle =
+    n.type === "comment"
+      ? n.context?.title
+      : n.type === "reply"
+        ? n.context?.myComment
+        : (n.text ?? "");
 
   return (
     <article
+      role={clickable ? (path ? "link" : "button") : undefined}
+      tabIndex={clickable ? 0 : undefined}
       className={[
         "relative rounded-xl border p-3 md:p-4 transition-colors",
         n.read
           ? "bg-base-300 border-base-300 text-neutral-content"
           : "bg-base-200 border-base-300",
+        clickable ? "cursor-pointer hover:bg-base-100/40" : "cursor-default",
       ].join(" ")}
+      // TODO: UI만 작업함, 실제 이동/읽음 로직은 후속 이슈에서 연결
+      onClick={undefined}
+      title={rawForTitle || undefined}
     >
-      {/* 삭제모드일 때 X 버튼(우상단) */}
+      {/* 삭제모드: 우상단 X */}
       {deleteMode && (
         <button
           type="button"
           aria-label="알림 삭제"
-          className="absolute right-3 top-3 w-6 h-6 rounded-full flex items-center justify-center opacity-90 hover:opacity-100"
+          className="absolute right-2 top-2 w-6 h-6 rounded-full flex items-center justify-center opacity-90 hover:opacity-100"
         >
-          <span className="text-base leading-none">×</span>
+          <span className="text-base text-primary-content leading-none">×</span>
         </button>
       )}
 
-      {/* 안읽음 배지: 우상단 (삭제모드 아니면 노출) */}
+      {/* 안읽음 배지: 우상단(삭제모드 아닐 때만) */}
       {!n.read && !deleteMode && (
         <i
           aria-hidden
@@ -41,17 +58,27 @@ export default function NoticeCard({
         />
       )}
 
+      {/* 내용 영역 */}
       <div className="flex items-start gap-2 pr-8">
         <div className="min-w-0 w-full">
-          {/* 1줄: 타입별 카피 */}
-          <p className="text-sm md:text-base leading-snug truncate">{copy}</p>
-          {/* 2줄: 실제 내용 */}
+          {/* 1) 첫째 줄: “ + snippet(길어지면 … 처리) + ” + suffix(항상 보임) */}
+          <div className="flex items-baseline whitespace-nowrap overflow-hidden text-xs md:text-sm text-neutral-content">
+            {isQuoted && <span className="flex-none">“</span>}
+            <span className="min-w-0 shrink truncate">{snippet}</span>
+            {isQuoted && <span className="flex-none">”</span>}
+            {suffix && <span className="flex-none pl-1">{suffix}</span>}
+          </div>
+
+          {/* 2) 둘째 줄 */}
           {detail && (
-            <p className="mt-1 text-sm md:text-base truncate">{detail}</p>
+            <p className="mt-1 text-sm md:text-base text-base-content font-medium truncate">
+              {detail}
+            </p>
           )}
-          {/* 3줄: 시간(우측 정렬) */}
-          <div className="mt-1 flex justify-end">
-            <time className="text-xs opacity-70">{time}</time>
+
+          {/* 3) 셋째 줄: 알림 발생 시각 */}
+          <div className="mt-1 flex justify-end -mr-8">
+            <time className="text-xs text-neutral-content">{time}</time>
           </div>
         </div>
       </div>

--- a/src/components/Notice/NoticeCard.tsx
+++ b/src/components/Notice/NoticeCard.tsx
@@ -1,0 +1,60 @@
+import type { Notification } from "./notice.types";
+import { toMdHm } from "./format";
+import { buildNoticeCopy } from "./copy";
+
+export default function NoticeCard({
+  n,
+  deleteMode,
+}: {
+  n: Notification;
+  deleteMode: boolean;
+}) {
+  const copy = buildNoticeCopy(n);
+  const detail = n.detail ?? "";
+  const time = toMdHm(n.createdAt);
+
+  return (
+    <article
+      className={[
+        "relative rounded-xl border p-3 md:p-4 transition-colors",
+        n.read
+          ? "bg-base-300 border-base-300 text-neutral-content"
+          : "bg-base-200 border-base-300",
+      ].join(" ")}
+    >
+      {/* 삭제모드일 때 X 버튼(우상단) */}
+      {deleteMode && (
+        <button
+          type="button"
+          aria-label="알림 삭제"
+          className="absolute right-3 top-3 w-6 h-6 rounded-full flex items-center justify-center opacity-90 hover:opacity-100"
+        >
+          <span className="text-base leading-none">×</span>
+        </button>
+      )}
+
+      {/* 안읽음 배지: 우상단 (삭제모드 아니면 노출) */}
+      {!n.read && !deleteMode && (
+        <i
+          aria-hidden
+          className="absolute right-3 top-3 inline-block w-2 h-2 rounded-full bg-error"
+        />
+      )}
+
+      <div className="flex items-start gap-2 pr-8">
+        <div className="min-w-0 w-full">
+          {/* 1줄: 타입별 카피 */}
+          <p className="text-sm md:text-base leading-snug truncate">{copy}</p>
+          {/* 2줄: 실제 내용 */}
+          {detail && (
+            <p className="mt-1 text-sm md:text-base truncate">{detail}</p>
+          )}
+          {/* 3줄: 시간(우측 정렬) */}
+          <div className="mt-1 flex justify-end">
+            <time className="text-xs opacity-70">{time}</time>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/Notice/NoticeCard.tsx
+++ b/src/components/Notice/NoticeCard.tsx
@@ -32,18 +32,20 @@ export default function NoticeCard({
   const normalReadBg = "bg-base-200";
   const baseBgClass = isSystem
     ? n.read
-      ? "bg-info/5  border-info/30"
-      : "bg-info/10 border-info/50"
+      ? "bg-info/15 border-info/30"
+      : "bg-info/30 border-info/50"
     : n.read
       ? `${normalReadBg} border-base-300`
       : `${normalUnreadBg} border-base-300`;
 
+  // hover: 배경 색 고정 + "오버레이 레이어"만 아주 살짝(배경만) 보이게
+  // - 클릭 가능한 상태에서만 적용
   const hoverOverlayClass = clickable
     ? isSystem
       ? "group-hover:bg-info/10"
       : isDark
-        ? "group-hover:bg-white/5" // 다크에선 밝은 오버레이
-        : "group-hover:bg-black/5" // 라이트에선 어두운 오버레이
+        ? "group-hover:bg-white/5"
+        : "group-hover:bg-black/5"
     : "";
 
   // 그림자: 읽음은 없음, 안 읽음만 hover 시 살짝 업(강도 낮게)
@@ -55,6 +57,7 @@ export default function NoticeCard({
       role={clickable ? (path ? "link" : "button") : undefined}
       tabIndex={clickable ? 0 : undefined}
       className={[
+        // 오버레이가 카드 안에서 깔끔하게 동작하도록 group/overflow-hidden 추가
         "relative group overflow-hidden rounded-xl border p-3 md:p-4 transition-all",
         baseBgClass,
         elevationBase,
@@ -65,7 +68,7 @@ export default function NoticeCard({
       onClick={undefined}
       title={rawForTitle || undefined}
     >
-      {/* 배경 오버레이: hover 시에만 살짝 보임 (텍스트에는 영향 없음) */}
+      {/* 배경 오버레이: hover 시에만 살짝 보임 */}
       <span
         aria-hidden
         className={[
@@ -97,7 +100,7 @@ export default function NoticeCard({
       <div className="flex items-start gap-2 pr-8 relative z-[1]">
         <div className="min-w-0 w-full">
           {/* 1) 첫째 줄: “ + snippet(길어지면 … 처리) + ” + suffix(항상 보임) */}
-          <div className="flex items-baseline whitespace-nowrap overflow-hidden text-xs md:text-sm text-neutral-content">
+          <div className="flex items-baseline whitespace-nowrap overflow-hidden text-xs md:text-sm text-base-content/70">
             {isQuoted && <span className="flex-none">“</span>}
             <span className="min-w-0 shrink truncate">{snippet}</span>
             {isQuoted && <span className="flex-none">”</span>}
@@ -113,7 +116,7 @@ export default function NoticeCard({
 
           {/* 3) 셋째 줄: 알림 발생 시각 */}
           <div className="mt-1 flex justify-end -mr-8">
-            <time className="text-xs text-neutral-content">{time}</time>
+            <time className="text-xs text-base-content/70">{time}</time>
           </div>
         </div>
       </div>

--- a/src/components/Notice/NoticeHeader.tsx
+++ b/src/components/Notice/NoticeHeader.tsx
@@ -21,12 +21,12 @@ export default function NoticeHeader({
   const tip = deleteMode ? "삭제모드 해제" : "삭제모드";
 
   return (
-    <header className="h-12 px-3 md:px-4 border-b border-base-300 flex items-center justify-between">
+    <header className="h-12 px-3 md:px-4 border-b border-primary-content/10 flex items-center justify-between">
       <h2 id="notice-title" className="text-base md:text-lg font-semibold">
         알림
       </h2>
 
-      <div className="flex items-center gap-1 md:gap-2">
+      <div className="flex items-center gap-1.5 md:gap-2">
         {/* 삭제모드 토글 */}
         <button
           type="button"
@@ -72,7 +72,7 @@ function DeleteAllButton() {
   return (
     <button
       type="button"
-      className="btn btn-error btn-xs text-error-content"
+      className="btn btn-error btn-xs text-primary-content"
       aria-label="모두 삭제"
     >
       모두 삭제

--- a/src/components/Notice/NoticeHeader.tsx
+++ b/src/components/Notice/NoticeHeader.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "./useTheme";
-import IconDeleteDark from "@/assets/icons/icon-delete-dark.svg";
-import IconDeleteLight from "@/assets/icons/icon-delete-light.svg";
-import IconDeleteOn from "@/assets/icons/icon-delete.svg";
+import IconDeleteDark from "@assets/icons/icon-delete-dark.svg";
+import IconDeleteLight from "@assets/icons/icon-delete-light.svg";
+import IconDeleteOn from "@assets/icons/icon-delete.svg";
 
 export default function NoticeHeader({
   deleteMode,
@@ -26,20 +26,19 @@ export default function NoticeHeader({
         알림
       </h2>
 
-      <div className="flex items-center gap-1.5 md:gap-2">
+      <div className="flex items-center gap-1 md:gap-2">
         {/* 삭제모드 토글 */}
-        <div className="tooltip tooltip-bottom" data-tip={tip}>
-          <button
-            type="button"
-            onClick={onToggleDeleteMode}
-            className="btn btn-ghost btn-sm"
-            aria-pressed={deleteMode}
-            aria-label={tip}
-          >
-            <img src={icon} alt="" className="w-4 h-4" />
-            <span className="sr-only">{tip}</span>
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={onToggleDeleteMode}
+          className="btn btn-ghost btn-xs tooltip tooltip-bottom"
+          data-tip={tip}
+          aria-pressed={deleteMode}
+          aria-label={tip}
+        >
+          <img src={icon} alt="" className="block w-4 h-4" />
+          <span className="sr-only">{tip}</span>
+        </button>
 
         {deleteMode ? <DeleteAllButton /> : <MarkAllReadButton />}
 
@@ -47,7 +46,7 @@ export default function NoticeHeader({
         <button
           type="button"
           onClick={onRequestClose}
-          className="btn btn-ghost btn-sm md:hidden w-10 h-10 p-0 rounded-full"
+          className="btn btn-ghost btn-xs md:hidden w-6 h-6 p-0 rounded-full"
           aria-label="알림 닫기"
         >
           <span className="text-lg leading-none">×</span>
@@ -61,7 +60,7 @@ function MarkAllReadButton() {
   return (
     <button
       type="button"
-      className="btn btn-ghost btn-sm"
+      className="btn btn-ghost btn-xs"
       aria-label="모두 읽음 처리"
     >
       모두 읽음
@@ -73,7 +72,7 @@ function DeleteAllButton() {
   return (
     <button
       type="button"
-      className="btn btn-error btn-sm text-error-content"
+      className="btn btn-error btn-xs text-error-content"
       aria-label="모두 삭제"
     >
       모두 삭제

--- a/src/components/Notice/NoticeHeader.tsx
+++ b/src/components/Notice/NoticeHeader.tsx
@@ -1,0 +1,82 @@
+import { useTheme } from "./useTheme";
+import IconDeleteDark from "@/assets/icons/icon-delete-dark.svg";
+import IconDeleteLight from "@/assets/icons/icon-delete-light.svg";
+import IconDeleteOn from "@/assets/icons/icon-delete.svg";
+
+export default function NoticeHeader({
+  deleteMode,
+  onToggleDeleteMode,
+  onRequestClose,
+}: {
+  deleteMode: boolean;
+  onToggleDeleteMode: () => void;
+  onRequestClose: () => void;
+}) {
+  const { isDark } = useTheme();
+  const icon = deleteMode
+    ? IconDeleteOn
+    : isDark
+      ? IconDeleteDark
+      : IconDeleteLight;
+  const tip = deleteMode ? "삭제모드 해제" : "삭제모드";
+
+  return (
+    <header className="h-12 px-3 md:px-4 border-b border-base-300 flex items-center justify-between">
+      <h2 id="notice-title" className="text-base md:text-lg font-semibold">
+        알림
+      </h2>
+
+      <div className="flex items-center gap-1.5 md:gap-2">
+        {/* 삭제모드 토글 */}
+        <div className="tooltip tooltip-bottom" data-tip={tip}>
+          <button
+            type="button"
+            onClick={onToggleDeleteMode}
+            className="btn btn-ghost btn-sm"
+            aria-pressed={deleteMode}
+            aria-label={tip}
+          >
+            <img src={icon} alt="" className="w-4 h-4" />
+            <span className="sr-only">{tip}</span>
+          </button>
+        </div>
+
+        {deleteMode ? <DeleteAllButton /> : <MarkAllReadButton />}
+
+        {/* 모바일 full-height 닫기 */}
+        <button
+          type="button"
+          onClick={onRequestClose}
+          className="btn btn-ghost btn-sm md:hidden w-10 h-10 p-0 rounded-full"
+          aria-label="알림 닫기"
+        >
+          <span className="text-lg leading-none">×</span>
+        </button>
+      </div>
+    </header>
+  );
+}
+
+function MarkAllReadButton() {
+  return (
+    <button
+      type="button"
+      className="btn btn-ghost btn-sm"
+      aria-label="모두 읽음 처리"
+    >
+      모두 읽음
+    </button>
+  );
+}
+
+function DeleteAllButton() {
+  return (
+    <button
+      type="button"
+      className="btn btn-error btn-sm text-error-content"
+      aria-label="모두 삭제"
+    >
+      모두 삭제
+    </button>
+  );
+}

--- a/src/components/Notice/NoticeHeader.tsx
+++ b/src/components/Notice/NoticeHeader.tsx
@@ -2,6 +2,13 @@ import { useTheme } from "./useTheme";
 import IconDeleteDark from "@assets/icons/icon-delete-dark.svg";
 import IconDeleteLight from "@assets/icons/icon-delete-light.svg";
 import IconDeleteOn from "@assets/icons/icon-delete.svg";
+import type { CSSProperties } from "react";
+
+type TooltipVars = CSSProperties & {
+  /** DaisyUI tooltip custom properties */
+  ["--tooltip-color"]?: string;
+  ["--tooltip-text-color"]?: string;
+};
 
 export default function NoticeHeader({
   deleteMode,
@@ -20,13 +27,18 @@ export default function NoticeHeader({
       : IconDeleteLight;
   const tip = deleteMode ? "삭제모드 해제" : "삭제모드";
 
+  const tooltipStyle: TooltipVars = {
+    "--tooltip-color": isDark ? "#2C2C2C" : "#1A1A1A",
+    "--tooltip-text-color": "#F5F5F5",
+  };
+
   return (
-    <header className="h-12 px-3 md:px-4 border-b border-primary-content/10 flex items-center justify-between">
+    <header className="relative z-10 h-12 px-3 md:px-4 border-b border-base-300 flex items-center justify-between">
       <h2 id="notice-title" className="text-base md:text-lg font-semibold">
         알림
       </h2>
 
-      <div className="flex items-center gap-1.5 md:gap-2">
+      <div className="flex items-center gap-1 md:gap-2">
         {/* 삭제모드 토글 */}
         <button
           type="button"
@@ -35,6 +47,7 @@ export default function NoticeHeader({
           data-tip={tip}
           aria-pressed={deleteMode}
           aria-label={tip}
+          style={tooltipStyle}
         >
           <img src={icon} alt="" className="block w-4 h-4" />
           <span className="sr-only">{tip}</span>
@@ -46,7 +59,7 @@ export default function NoticeHeader({
         <button
           type="button"
           onClick={onRequestClose}
-          className="btn btn-ghost btn-xs md:hidden w-6 h-6 p-0 rounded-full"
+          className="btn btn-ghost btn-sm md:hidden w-8 h-8 p-0 rounded-full"
           aria-label="알림 닫기"
         >
           <span className="text-lg leading-none">×</span>
@@ -72,7 +85,7 @@ function DeleteAllButton() {
   return (
     <button
       type="button"
-      className="btn btn-error btn-xs text-primary-content"
+      className="btn btn-error btn-xs text-white"
       aria-label="모두 삭제"
     >
       모두 삭제

--- a/src/components/Notice/NoticeList.tsx
+++ b/src/components/Notice/NoticeList.tsx
@@ -1,0 +1,24 @@
+import { MOCK_NOTICES } from "./notice.mock";
+import NoticeCard from "./NoticeCard";
+
+export default function NoticeList({ deleteMode }: { deleteMode: boolean }) {
+  const items = MOCK_NOTICES; // ❗️ 정적 데이터(더미) -> 추후 교체
+
+  if (!items.length) {
+    return (
+      <div className="py-20 text-center text-sm text-neutral-content">
+        새 알림이 없습니다
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {items.map((n) => (
+        <li key={n.id}>
+          <NoticeCard n={n} deleteMode={deleteMode} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/Notice/NotificationModal.tsx
+++ b/src/components/Notice/NotificationModal.tsx
@@ -42,7 +42,7 @@ export default function NotificationModal({ open, onClose }: Props) {
       <button
         aria-label="모달 닫기"
         onClick={handleClose}
-        className="absolute inset-0 bg-black/60"
+        className="absolute inset-0 bg-black/60 cursor-default"
       />
       {/* 패널 */}
       <section

--- a/src/components/Notice/NotificationModal.tsx
+++ b/src/components/Notice/NotificationModal.tsx
@@ -35,6 +35,7 @@ export default function NotificationModal({ open, onClose }: Props) {
 
   if (!open) return null;
 
+  // TODO: 테스트용 스타일로, 추후 위치 조정 필요(알림 버튼 옆)
   return (
     <div className="fixed inset-0 z-[2000]">
       {/* 오버레이(바깥 클릭 시 닫기) */}

--- a/src/components/Notice/NotificationModal.tsx
+++ b/src/components/Notice/NotificationModal.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import NoticeHeader from "./NoticeHeader";
+import NoticeList from "./NoticeList";
+import { useNoticeDeleteMode } from "./useNoticeDeleteMode";
+
+type Props = { open: boolean; onClose?: () => void };
+
+export default function NotificationModal({ open, onClose }: Props) {
+  const { deleteMode, toggleDeleteMode, resetDeleteMode } =
+    useNoticeDeleteMode();
+
+  const handleClose = () => {
+    onClose?.();
+    resetDeleteMode(); // 모달 닫힐 때 삭제모드 초기화
+  };
+
+  useEffect(() => {
+    if (!open) return;
+
+    // ESC 닫기 + 바디 스크롤 잠금
+    const h = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleClose();
+    };
+    window.addEventListener("keydown", h);
+
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      window.removeEventListener("keydown", h);
+      document.body.style.overflow = prev;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[2000]">
+      {/* 오버레이(바깥 클릭 시 닫기) */}
+      <button
+        aria-label="모달 닫기"
+        onClick={handleClose}
+        className="absolute inset-0 bg-black/60"
+      />
+      {/* 패널 */}
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="notice-title"
+        className="
+          absolute left-1/2 -translate-x-1/2 top-0 md:top-20
+          w-full md:w-[560px]
+          h-dvh md:h-auto md:max-h-[80vh]
+          bg-base-200 md:rounded-2xl shadow-2xl
+          flex flex-col
+        "
+      >
+        <NoticeHeader
+          deleteMode={deleteMode}
+          onToggleDeleteMode={toggleDeleteMode}
+          onRequestClose={handleClose}
+        />
+        <div className="flex-1 overflow-y-auto p-2 md:p-3">
+          <NoticeList deleteMode={deleteMode} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/Notice/copy.ts
+++ b/src/components/Notice/copy.ts
@@ -1,22 +1,23 @@
 import type { Notification } from "./notice.types";
 
-function quoteSnippet(src?: string, max = 36) {
-  if (!src) return "“”";
+function clip(src?: string, max = 36) {
+  if (!src) return "";
   const s = src.trim();
-  const clipped = s.length > max ? s.slice(0, max) + "…" : s;
-  return `“${clipped}”`;
+  return s.length > max ? s.slice(0, max) + "…" : s;
 }
 
-/** 1줄(상단) 카피: 타입별 생성 */
-export function buildNoticeCopy(n: Notification): string {
+export function buildNoticeCopy(n: Notification): {
+  snippet: string;
+  suffix: string;
+} {
   const c = n.context;
   switch (n.type) {
     case "comment":
-      return `${quoteSnippet(c?.title)}에 댓글이 달렸습니다.`;
+      return { snippet: clip(c?.title), suffix: "에 댓글이 달렸습니다." };
     case "reply":
-      return `${quoteSnippet(c?.myComment)}에 답글이 달렸습니다.`;
+      return { snippet: clip(c?.myComment), suffix: "에 답글이 달렸습니다." };
     case "system":
     default:
-      return n.text ?? "";
+      return { snippet: n.text ?? "", suffix: "" };
   }
 }

--- a/src/components/Notice/copy.ts
+++ b/src/components/Notice/copy.ts
@@ -1,0 +1,22 @@
+import type { Notification } from "./notice.types";
+
+function quoteSnippet(src?: string, max = 36) {
+  if (!src) return "“”";
+  const s = src.trim();
+  const clipped = s.length > max ? s.slice(0, max) + "…" : s;
+  return `“${clipped}”`;
+}
+
+/** 1줄(상단) 카피: 타입별 생성 */
+export function buildNoticeCopy(n: Notification): string {
+  const c = n.context;
+  switch (n.type) {
+    case "comment":
+      return `${quoteSnippet(c?.title)}에 댓글이 달렸습니다.`;
+    case "reply":
+      return `${quoteSnippet(c?.myComment)}에 답글이 달렸습니다.`;
+    case "system":
+    default:
+      return n.text ?? "";
+  }
+}

--- a/src/components/Notice/format.ts
+++ b/src/components/Notice/format.ts
@@ -1,0 +1,8 @@
+export function toMdHm(iso: string) {
+  const d = new Date(iso);
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${mm}.${dd} ${hh}:${mi}`;
+}

--- a/src/components/Notice/index.ts
+++ b/src/components/Notice/index.ts
@@ -1,0 +1,2 @@
+export { default as NotificationModal } from "./NotificationModal";
+export * from "./notice.types";

--- a/src/components/Notice/notice.mock.ts
+++ b/src/components/Notice/notice.mock.ts
@@ -4,38 +4,31 @@ export const MOCK_NOTICES: Notification[] = [
   {
     id: "n1",
     type: "comment",
-    text: "", // 사용 안 함
     createdAt: "2025-08-05T11:07:00Z",
     read: false,
-    context: {
-      board: "자유게시판",
-      title: "나도 없어.. 고양이",
-      path: "/posts/123#comment-456",
-    },
+    context: { title: "나만 고양이 없어ㅜㅜ", path: "/posts/123#comment-456" },
+    detail: "나도 없어.. 고양이", // 상대가 남긴 '댓글' 내용
   },
   {
     id: "n2",
     type: "reply",
-    text: "", // 사용 안 함
     createdAt: "2025-08-04T11:07:00Z",
     read: true,
     context: {
-      board: "간식토론",
-      title: "붕어싸만코가 더 맛있더라",
-      myComment: "난 요즘 붕어싸만코가 더 맛있더라",
+      title: "황치즈 뿅또아 맛있지 않음?",
+      myComment:
+        "난 요즘 붕어싸만코가 더 맛있더라. 이유를 쓰자면 한도 끝도 없지만, 아무튼 근본 아이스크림이 제일 좋은 듯. 변치 않는 맛 최고야.",
       path: "/posts/789#comment-321",
     },
+    detail:
+      "맞죠! 근데 전 찰떡 아이스 파예요. 지피티가 제 말 찰떡같이 알아들어 주길 바라며 하나하나 먹고 있답니다. 쫄깃한 식감에 더해, 그렇게 먹는 맛이 있는 것 같아요.", // 상대가 남긴 '답글' 내용
   },
   {
     id: "n3",
     type: "system",
-    text: "시스템 점검 안내",
     createdAt: "2025-08-04T09:11:00Z",
     read: false,
-    context: {
-      board: "공지",
-      title: "다음 주 일정 안내(긴 제목 예시)",
-      path: "/notice/11",
-    },
+    text: "시스템 점검 안내",
+    detail: "25/08/06 02:00~03:00 점검 예정입니다.",
   },
 ];

--- a/src/components/Notice/notice.mock.ts
+++ b/src/components/Notice/notice.mock.ts
@@ -15,7 +15,6 @@ export const MOCK_NOTICES: Notification[] = [
     createdAt: "2025-08-04T11:07:00Z",
     read: true,
     context: {
-      title: "황치즈 뿅또아 맛있지 않음?",
       myComment:
         "난 요즘 붕어싸만코가 더 맛있더라. 이유를 쓰자면 한도 끝도 없지만, 아무튼 근본 아이스크림이 제일 좋은 듯. 변치 않는 맛 최고야.",
       path: "/posts/789#comment-321",
@@ -30,5 +29,13 @@ export const MOCK_NOTICES: Notification[] = [
     read: false,
     text: "시스템 점검 안내",
     detail: "25/08/06 02:00~03:00 점검 예정입니다.",
+  },
+  {
+    id: "n4",
+    type: "system",
+    createdAt: "2025-08-02T16:20:00Z",
+    read: true,
+    text: "조교의 목소리",
+    detail: "여러분 운만조 참여해 주세요.",
   },
 ];

--- a/src/components/Notice/notice.mock.ts
+++ b/src/components/Notice/notice.mock.ts
@@ -1,0 +1,41 @@
+import type { Notification } from "./notice.types";
+
+export const MOCK_NOTICES: Notification[] = [
+  {
+    id: "n1",
+    type: "comment",
+    text: "", // 사용 안 함
+    createdAt: "2025-08-05T11:07:00Z",
+    read: false,
+    context: {
+      board: "자유게시판",
+      title: "나도 없어.. 고양이",
+      path: "/posts/123#comment-456",
+    },
+  },
+  {
+    id: "n2",
+    type: "reply",
+    text: "", // 사용 안 함
+    createdAt: "2025-08-04T11:07:00Z",
+    read: true,
+    context: {
+      board: "간식토론",
+      title: "붕어싸만코가 더 맛있더라",
+      myComment: "난 요즘 붕어싸만코가 더 맛있더라",
+      path: "/posts/789#comment-321",
+    },
+  },
+  {
+    id: "n3",
+    type: "system",
+    text: "시스템 점검 안내",
+    createdAt: "2025-08-04T09:11:00Z",
+    read: false,
+    context: {
+      board: "공지",
+      title: "다음 주 일정 안내(긴 제목 예시)",
+      path: "/notice/11",
+    },
+  },
+];

--- a/src/components/Notice/notice.types.ts
+++ b/src/components/Notice/notice.types.ts
@@ -1,7 +1,17 @@
+export type NoticeType = "comment" | "reply" | "system";
+
+export type NoticeContext = {
+  board?: string; // 게시판/섹션명
+  title?: string; // 원글(게시글) 제목
+  myComment?: string; // 내가 쓴 댓글 내용(답글 알림용)
+  path?: string; // 라우팅 경로(추후 이동)
+};
+
 export type Notification = {
   id: string;
-  text: string; // 알림 내용
+  text: string; // // system일 때 사용, 나머지 타입은 빌드된 카피가 우선
   createdAt: string; // 렌더: mm.dd hh:mm
   read: boolean; // 읽음 여부
-  href?: string; // 추후 상세 이동용
+  type: NoticeType;
+  context?: NoticeContext;
 };

--- a/src/components/Notice/notice.types.ts
+++ b/src/components/Notice/notice.types.ts
@@ -1,7 +1,7 @@
 export type NoticeType = "comment" | "reply" | "system";
 
 export type NoticeContext = {
-  board?: string; // 게시판/섹션명 (추후 게시판 타입으로 대체 가능)
+  board?: string; // 게시판/섹션명 (TODO: 추후 게시판 타입으로 대체 가능)
   title?: string; // 내가 쓴 '게시글 제목' (comment용)
   myComment?: string; // 내가 쓴 '댓글 내용' (reply용)
   path?: string; // 클릭 시 라우팅 경로

--- a/src/components/Notice/notice.types.ts
+++ b/src/components/Notice/notice.types.ts
@@ -1,17 +1,27 @@
 export type NoticeType = "comment" | "reply" | "system";
 
 export type NoticeContext = {
-  board?: string; // 게시판/섹션명
-  title?: string; // 원글(게시글) 제목
-  myComment?: string; // 내가 쓴 댓글 내용(답글 알림용)
-  path?: string; // 라우팅 경로(추후 이동)
+  board?: string; // 게시판/섹션명 (추후 게시판 타입으로 대체 가능)
+  title?: string; // 내가 쓴 '게시글 제목' (comment용)
+  myComment?: string; // 내가 쓴 '댓글 내용' (reply용)
+  path?: string; // 클릭 시 라우팅 경로
 };
 
 export type Notification = {
   id: string;
-  text: string; // // system일 때 사용, 나머지 타입은 빌드된 카피가 우선
+  type: NoticeType;
   createdAt: string; // 렌더: mm.dd hh:mm
   read: boolean; // 읽음 여부
-  type: NoticeType;
+
+  // 1줄: 상단 카피(타입별로 생성)
+  text?: string;
+
+  /** 2줄차에 노출할 실제 내용:
+   *  - comment: '상대가 남긴 댓글 내용'
+   *  - reply:   '상대가 남긴 답글 내용'
+   *  - system:  '상세 설명(옵션)'
+   */
+  detail?: string;
+
   context?: NoticeContext;
 };

--- a/src/components/Notice/notice.types.ts
+++ b/src/components/Notice/notice.types.ts
@@ -1,0 +1,7 @@
+export type Notification = {
+  id: string;
+  text: string; // 알림 내용
+  createdAt: string; // 렌더: mm.dd hh:mm
+  read: boolean; // 읽음 여부
+  href?: string; // 추후 상세 이동용
+};

--- a/src/components/Notice/useNoticeDeleteMode.ts
+++ b/src/components/Notice/useNoticeDeleteMode.ts
@@ -1,0 +1,9 @@
+import { useState } from "react";
+
+/** 알림 패널 내 '삭제 모드' 전용 UI 상태 훅 */
+export function useNoticeDeleteMode() {
+  const [deleteMode, setDeleteMode] = useState(false);
+  const toggleDeleteMode = () => setDeleteMode((v) => !v);
+  const resetDeleteMode = () => setDeleteMode(false);
+  return { deleteMode, toggleDeleteMode, resetDeleteMode };
+}

--- a/src/components/Notice/useTheme.ts
+++ b/src/components/Notice/useTheme.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/** DaisyUI: <html data-theme="oz_dark" | "oz_light"> 를 구독 */
+export function useTheme() {
+  const get = () =>
+    (document.documentElement.dataset.theme ?? "").toLowerCase();
+  const [theme, setTheme] = useState<string>(get());
+
+  useEffect(() => {
+    const el = document.documentElement;
+    const obs = new MutationObserver(() => setTheme(get()));
+    obs.observe(el, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => obs.disconnect();
+  }, []);
+
+  return { theme, isDark: theme.includes("dark") };
+}

--- a/src/pages/test/TestHub.tsx
+++ b/src/pages/test/TestHub.tsx
@@ -1,16 +1,20 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { PATHS } from "@constants/paths";
 import { useAuthStore } from "@store/authStore";
 import { useLogoutMutation } from "@hooks/useAuthQueries";
 import { useToastStore } from "@store/toastStore";
+import { NotificationModal } from "@components/Notice";
 
 export default function TestHub() {
+  const [noticeOpen, setNoticeOpen] = useState(false);
+
   const items = [
     { to: "/test/write", label: "게시글 작성 테스트" },
     { to: "/403", label: "403 테스트" },
     { to: "/500", label: "500 테스트" },
     // 404는 없는 주소
-    // --- 인증 관련 테스트 링크 추가 ---
+    // --- 인증 관련 테스트 링크 ---
     { to: PATHS.AUTH, label: "로그인/회원가입(로비) 테스트" },
     { to: PATHS.MAIN, label: "보호 라우트: /main (JWT + 인증 완료)" },
     { to: PATHS.KEY_VERIFY, label: "보호 라우트: /key-verify (JWT + 미인증)" },
@@ -54,6 +58,15 @@ export default function TestHub() {
         >
           404 테스트
         </Link>
+
+        {/* 🔔 알림 모달 UI 테스트 (라우팅 없이 띄우기) */}
+        <button
+          type="button"
+          onClick={() => setNoticeOpen(true)}
+          className="rounded-xl border px-4 py-3 text-center hover:bg-gray-50 active:scale-[0.98] transition"
+        >
+          알림 모달 UI 테스트
+        </button>
       </div>
 
       {/* 인증 상태 패널 */}
@@ -116,6 +129,12 @@ export default function TestHub() {
           이동합니다.
         </p>
       </section>
+
+      {/* 🔔 알림 모달 (UI만) */}
+      <NotificationModal
+        open={noticeOpen}
+        onClose={() => setNoticeOpen(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 핵심 기능
- UI만 작업: 더미 데이터 렌더, 클릭 로직(읽음/삭제/이동) 없음 (정적)
- 닫기 기능: **오버레이 클릭 / ESC / 모바일 닫기 버튼 +** 닫히면 **삭제모드 상태 초기화**
- 헤더: 휴지통(툴팁), **모두 읽음 ↔ 모두 삭제** 버튼
- 카드:
    - 1줄: `“제목/내댓글(…로만 줄임)” + “에 댓글/답글이 달렸습니다.”`
    - 2줄: 본문 내용
    - 3줄: 알림 발생 시각(mm.dd hh:mm)
    - **삭제모드 아님** → clickable 커서 포인터(향후 읽음 처리/path 이동 연결 용도)
    - **삭제모드** → unclickable 우상단 X만 노출
- 반응형: 모바일(md 미만) **full-height**, 데스크톱 **폭 560px / max-h 80vh**.
- 열릴 때 **body 스크롤 잠금**, z-index **2000 설정**
- 테마 구독하여 연결함(useTheme.ts)

## 테스트 방법
TestHub에 알림 모달 UI 테스트 기능 추가했습니다.
해당 버튼 클릭 후 반응형도 확인해 보세요.

## 알림 모달 사용법
1. import
`import { NotificationModal } from "@/components/Notice";`

2. 열기/닫기 상태(useState) 추가
```tsx
import { useState } from "react";
import { NotificationModal } from "@/components/Notice";

export default function AnyPage() {
  const [open, setOpen] = useState(false);

  return (
    <>
      <button className="btn btn-ghost" onClick={() => setOpen(true)}>알림</button>
      <NotificationModal open={open} onClose={() => setOpen(false)} />
    </>
  );
}
```

## 구현 이미지
### 데스크탑
<img width="641" height="439" alt="image" src="https://github.com/user-attachments/assets/5a375e9f-ad27-4537-9ac8-a3b30174f194" />
<img width="607" height="441" alt="image" src="https://github.com/user-attachments/assets/e7df8cb8-25b1-439f-a39f-d56bf69c6f7b" />

### 모바일
<img width="375" height="928" alt="image" src="https://github.com/user-attachments/assets/ce83a318-e42a-4f50-ae50-66c98c45768a" />
<img width="376" height="920" alt="image" src="https://github.com/user-attachments/assets/f6a6d780-05fd-4b73-96b4-e2387027adda" />

## 연관 이슈
https://github.com/OZblind/OZblind_FE/issues/11

---
closes #11 