### PR TITLE
[feat] 사용자 설정 모달 UI 컴포넌트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,20 +1,7 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en" data-theme="oz_dark">
   <head>
-    <script>
-      (function () {
-        try {
-          var theme = localStorage.getItem("theme");
-          if (!theme) {
-            let prefersDark = window.matchMedia(
-              "(prefers-color-scheme: dark)"
-            ).matches;
-            theme = prefersDark ? "oz_dark" : "oz_light";
-          }
-          document.documentElement.setAttribute("data-theme", theme);
-        } catch (e) {}
-      })();
-    </script>
+    <script type="module" src="/src/utils/themeInit.ts"></script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/oz-favicon.svg" />
     <link rel="icon" type="image/png" href="/oz-favicon.png" />

--- a/index.html
+++ b/index.html
@@ -1,6 +1,20 @@
 <!doctype html>
 <html lang="en" data-theme="oz_dark">
   <head>
+    <script>
+      (function () {
+        try {
+          var theme = localStorage.getItem("theme");
+          if (!theme) {
+            let prefersDark = window.matchMedia(
+              "(prefers-color-scheme: dark)"
+            ).matches;
+            theme = prefersDark ? "oz_dark" : "oz_light";
+          }
+          document.documentElement.setAttribute("data-theme", theme);
+        } catch (e) {}
+      })();
+    </script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/oz-favicon.svg" />
     <link rel="icon" type="image/png" href="/oz-favicon.png" />

--- a/src/components/commons/SettingModal/AccountDeletionSection.tsx
+++ b/src/components/commons/SettingModal/AccountDeletionSection.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+
+export function AccountDeletionSection() {
+  const [inputValue, setInputValue] = useState("");
+  const [isWarningVisible, setIsWarningVisible] = useState(false);
+  const [isConfirmVisible, setIsConfirmVisible] = useState(false);
+
+  const isValid = inputValue === "회원 탈퇴";
+
+  const handleDelete = () => {
+    if (isValid) {
+      setIsConfirmVisible(false);
+      // 탈퇴 처리 콜백
+    }
+  };
+
+  const handleToggle = () => {
+    if (isWarningVisible || isConfirmVisible) {
+      setIsWarningVisible(false);
+      setIsConfirmVisible(false);
+      setInputValue("");
+    } else {
+      setIsWarningVisible(true);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex items-center justify-between pt-6 pb-4">
+        <button
+          className="text-gray-400 hover:text-info"
+          onClick={handleToggle}
+        >
+          회원 탈퇴
+        </button>
+      </div>
+
+      {isWarningVisible && (
+        <div className="p-4 border-2 border-base-300 rounded mb-4">
+          <p className="pb-2">회원 탈퇴 시</p>
+          <div className="mb-2 bg-red-600/10 rounded p-2 text-red-600">
+            <p>• 회원 정보와 이용·인증 기록이 모두 삭제됩니다.</p>
+            <p>• 재가입 시 가입과 인증을 처음부터 진행해야 합니다.</p>
+            <p>• 삭제된 정보는 복구할 수 없습니다.</p>
+          </div>
+          <p className="text-info pb-1">정말 그림자 속으로 떠나버리겠습니까?</p>
+          <button
+            onClick={() => {
+              setIsConfirmVisible(true);
+              setIsWarningVisible(false);
+            }}
+            className="w-full py-2 rounded text-white bg-primary hover:bg-secondary transition"
+          >
+            확인했습니다
+          </button>
+        </div>
+      )}
+
+      {isConfirmVisible && (
+        <div className="p-4 border-2 border-base-300 rounded">
+          <p className="mb-2">탈퇴를 원하시면 "회원 탈퇴"라고 입력해 주세요.</p>
+          <input
+            type="text"
+            placeholder="회원 탈퇴"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            className="w-full p-2 border border-base-300 bg-base-100 rounded mb-1 focus:outline-none focus:border-primary"
+          />
+          <button
+            onClick={handleDelete}
+            disabled={!isValid}
+            className={`w-full py-2 rounded text-white ${
+              isValid
+                ? "bg-red-600 hover:bg-red-700"
+                : "bg-base-300 cursor-not-allowed"
+            } transition`}
+          >
+            회원 탈퇴
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/commons/SettingModal/KeySection.tsx
+++ b/src/components/commons/SettingModal/KeySection.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+
+export function KeySection() {
+  const [key, setKey] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+
+  const handleLogin = (): void => {
+    if (key === "123") {
+      setError("");
+      alert("로그인 성공");
+      setIsAuthenticated(true);
+    } else {
+      setError("유효하지 않은 키입니다.");
+      setIsAuthenticated(false);
+    }
+  };
+
+  return (
+    <div className="border-b border-neutral-content py-6">
+      <p className="mb-2">회원 인증</p>
+      {isAuthenticated ? (
+        <div className=" p-3 w-full bg-base-300 text-secondary rounded-md">
+          이미 인증된 사용자입니다.
+        </div>
+      ) : (
+        <div className="flex justify-between">
+          <input
+            type="text"
+            placeholder="발급받은 인증 키를 입력해 주세요."
+            value={key}
+            onChange={(e) => setKey(e.target.value)}
+            className="flex-1 min-w-0 bg-base-300 border border-base-200 p-2 focus:outline-none focus:border-primary rounded"
+          />
+          <button
+            onClick={handleLogin}
+            className="px-4 bg-primary text-white py-2 rounded hover:bg-secondary transition"
+          >
+            인증
+          </button>
+        </div>
+      )}
+      {error && <p className="text-error font-thin">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/commons/SettingModal/KeySection.tsx
+++ b/src/components/commons/SettingModal/KeySection.tsx
@@ -24,7 +24,13 @@ export function KeySection() {
           이미 인증된 사용자입니다.
         </div>
       ) : (
-        <div className="flex justify-between">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleLogin();
+          }}
+          className="flex justify-between"
+        >
           <input
             type="text"
             placeholder="발급받은 인증 키를 입력해 주세요."
@@ -33,12 +39,12 @@ export function KeySection() {
             className="flex-1 min-w-0 bg-base-300 border border-base-200 p-2 focus:outline-none focus:border-primary rounded"
           />
           <button
-            onClick={handleLogin}
+            type="submit"
             className="px-4 bg-primary text-white py-2 rounded hover:bg-secondary transition"
           >
             인증
           </button>
-        </div>
+        </form>
       )}
       {error && <p className="text-error font-thin">{error}</p>}
     </div>

--- a/src/components/commons/SettingModal/SettingsPage.tsx
+++ b/src/components/commons/SettingModal/SettingsPage.tsx
@@ -1,0 +1,27 @@
+import type { Dispatch, SetStateAction } from "react";
+import { SettingPopup } from "./SettingsPopup";
+
+type Theme = "oz_dark" | "oz_light";
+
+type Props = {
+  isOpen: boolean;
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  theme: Theme;
+  setTheme: Dispatch<SetStateAction<Theme>>;
+};
+
+export function SettingsPage({ isOpen, setIsOpen, theme, setTheme }: Props) {
+  return (
+    <>
+      {isOpen && (
+        <div className="fixed inset-0 bg-zinc-950 bg-opacity-50 flex justify-center items-center z-[2000]">
+          <SettingPopup
+            setIsOpen={setIsOpen}
+            theme={theme}
+            setTheme={setTheme}
+          />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/commons/SettingModal/SettingsPage.tsx
+++ b/src/components/commons/SettingModal/SettingsPage.tsx
@@ -3,14 +3,19 @@ import { SettingPopup } from "./SettingsPopup";
 
 type Theme = "oz_dark" | "oz_light";
 
-type Props = {
+interface SettingsPageProps {
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   theme: Theme;
   setTheme: Dispatch<SetStateAction<Theme>>;
-};
+}
 
-export function SettingsPage({ isOpen, setIsOpen, theme, setTheme }: Props) {
+export function SettingsPage({
+  isOpen,
+  setIsOpen,
+  theme,
+  setTheme,
+}: SettingsPageProps) {
   return (
     <>
       {isOpen && (

--- a/src/components/commons/SettingModal/SettingsPopup.tsx
+++ b/src/components/commons/SettingModal/SettingsPopup.tsx
@@ -1,0 +1,29 @@
+import type { Dispatch, SetStateAction } from "react";
+import { KeySection } from "./KeySection";
+import ThemeToggleSection from "./ThemeToggleSection";
+import { AccountDeletionSection } from "./AccountDeletionSection";
+
+type Theme = "oz_dark" | "oz_light";
+
+type Props = {
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  theme: Theme;
+  setTheme: Dispatch<SetStateAction<Theme>>;
+};
+
+export function SettingPopup({ setIsOpen, theme, setTheme }: Props) {
+  return (
+    <div className="relative bg-base-200 rounded-md p-6 max-w-md w-full h-[500px]">
+      <button
+        className="absolute top-4 right-4 px-4 text-base-content py-2 rounded-full hover:bg-base-300 transition"
+        onClick={() => setIsOpen(false)}
+      >
+        X
+      </button>
+      <div className="font-thin">설정</div>
+      <ThemeToggleSection theme={theme} setTheme={setTheme} />
+      <KeySection />
+      <AccountDeletionSection />
+    </div>
+  );
+}

--- a/src/components/commons/SettingModal/SettingsPopup.tsx
+++ b/src/components/commons/SettingModal/SettingsPopup.tsx
@@ -5,13 +5,17 @@ import { AccountDeletionSection } from "./AccountDeletionSection";
 
 type Theme = "oz_dark" | "oz_light";
 
-type Props = {
+interface SettingPopupProps {
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   theme: Theme;
   setTheme: Dispatch<SetStateAction<Theme>>;
-};
+}
 
-export function SettingPopup({ setIsOpen, theme, setTheme }: Props) {
+export function SettingPopup({
+  setIsOpen,
+  theme,
+  setTheme,
+}: SettingPopupProps) {
   const isAuthenticated = true; // 오즈키 인증 상태(임시)
   return (
     <div className="relative bg-base-200 rounded-md p-6 max-w-md w-full h-[500px]">

--- a/src/components/commons/SettingModal/SettingsPopup.tsx
+++ b/src/components/commons/SettingModal/SettingsPopup.tsx
@@ -12,11 +12,15 @@ type Props = {
 };
 
 export function SettingPopup({ setIsOpen, theme, setTheme }: Props) {
+  const isAuthenticated = true; // 오즈키 인증 상태(임시)
   return (
     <div className="relative bg-base-200 rounded-md p-6 max-w-md w-full h-[500px]">
       <button
         className="absolute top-4 right-4 px-4 text-base-content py-2 rounded-full hover:bg-base-300 transition"
-        onClick={() => setIsOpen(false)}
+        onClick={() => {
+          if (!isAuthenticated) return;
+          setIsOpen(false);
+        }}
       >
         X
       </button>

--- a/src/components/commons/SettingModal/ThemeInitializer.tsx
+++ b/src/components/commons/SettingModal/ThemeInitializer.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+type Theme = "oz_dark" | "oz_light";
+
+type Props = {
+  setTheme: (theme: Theme) => void;
+};
+
+export function ThemeInitializer({ setTheme }: Props) {
+  // 초기 로드 시 테마 설정
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme") as
+      | "oz_dark"
+      | "oz_light"
+      | null;
+
+    if (savedTheme) {
+      setTheme(savedTheme);
+      document.documentElement.setAttribute("data-theme", savedTheme);
+    } else {
+      // 브라우저 다크모드 감지
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      const initialTheme = prefersDark ? "oz_dark" : "oz_light";
+      setTheme(initialTheme);
+      document.documentElement.setAttribute("data-theme", initialTheme);
+    }
+  }, [setTheme]);
+
+  return null;
+}

--- a/src/components/commons/SettingModal/ThemeInitializer.tsx
+++ b/src/components/commons/SettingModal/ThemeInitializer.tsx
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 
 type Theme = "oz_dark" | "oz_light";
 
-type Props = {
+interface ThemeInitializerProps {
   setTheme: (theme: Theme) => void;
-};
+}
 
-export function ThemeInitializer({ setTheme }: Props) {
+export function ThemeInitializer({ setTheme }: ThemeInitializerProps) {
   // 초기 로드 시 테마 설정
   useEffect(() => {
     const savedTheme = localStorage.getItem("theme") as

--- a/src/components/commons/SettingModal/ThemeToggleSection.tsx
+++ b/src/components/commons/SettingModal/ThemeToggleSection.tsx
@@ -1,11 +1,14 @@
 type Theme = "oz_dark" | "oz_light";
 
-type Props = {
+interface ThemeToggleSectionProps {
   theme: Theme;
   setTheme: (theme: Theme) => void;
-};
+}
 
-export default function ThemeToggleSection({ theme, setTheme }: Props) {
+export default function ThemeToggleSection({
+  theme,
+  setTheme,
+}: ThemeToggleSectionProps) {
   const toggleTheme = () => {
     const newTheme = theme === "oz_dark" ? "oz_light" : "oz_dark";
     document.documentElement.setAttribute("data-theme", newTheme);

--- a/src/components/commons/SettingModal/ThemeToggleSection.tsx
+++ b/src/components/commons/SettingModal/ThemeToggleSection.tsx
@@ -1,0 +1,31 @@
+type Theme = "oz_dark" | "oz_light";
+
+type Props = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+};
+
+export default function ThemeToggleSection({ theme, setTheme }: Props) {
+  const toggleTheme = () => {
+    const newTheme = theme === "oz_dark" ? "oz_light" : "oz_dark";
+    document.documentElement.setAttribute("data-theme", newTheme);
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+  };
+
+  return (
+    <div className="flex items-center justify-between border-b border-neutral-content py-6">
+      라이트 모드
+      <button
+        onClick={toggleTheme}
+        className={`w-14 h-8 flex items-center rounded-full p-1 transition-colors duration-300
+    ${theme === "oz_dark" ? "bg-gray-700" : "bg-primary"}`}
+      >
+        <div
+          className={`w-6 h-6 rounded-full bg-white shadow-md transform transition-transform duration-300
+      ${theme === "oz_dark" ? "translate-x-0" : "translate-x-6"}`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/pages/test/TestHub.tsx
+++ b/src/pages/test/TestHub.tsx
@@ -13,6 +13,7 @@ export default function TestHub() {
     { to: "/test/write", label: "게시글 작성 테스트" },
     { to: "/403", label: "403 테스트" },
     { to: "/500", label: "500 테스트" },
+    { to: "/test/setting", label: "사용자 모달 테스트" },
     // 404는 없는 주소
     // --- 인증 관련 테스트 링크 ---
     { to: PATHS.AUTH, label: "로그인/회원가입(로비) 테스트" },

--- a/src/pages/test/TestSettingPage.tsx
+++ b/src/pages/test/TestSettingPage.tsx
@@ -1,0 +1,26 @@
+import { SettingsPage } from "@components/commons/SettingModal/SettingsPage";
+import { ThemeInitializer } from "@src/components/commons/SettingModal/ThemeInitializer";
+import { useState } from "react";
+
+export default function TestSettingPage() {
+  const [settingOpen, setSettingIsOpen] = useState<boolean>(false);
+  const [theme, setTheme] = useState<"oz_dark" | "oz_light">("oz_dark");
+  return (
+    <div className="w-screen h-screen flex flex-col justify-center items-center">
+      <button
+        type="button"
+        onClick={() => setSettingIsOpen(true)}
+        className="rounded-full border w-40 h-40 text-center"
+      >
+        프로필
+      </button>
+      <SettingsPage
+        isOpen={settingOpen}
+        setIsOpen={setSettingIsOpen}
+        theme={theme}
+        setTheme={setTheme}
+      />
+      <ThemeInitializer setTheme={setTheme} />
+    </div>
+  );
+}

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -17,6 +17,7 @@ import Error500 from "@pages/error/500";
 
 import TestHub from "@pages/test/TestHub"; // /
 import TestPostWritePage from "@pages/test/TestPostWritePage"; // /test/write
+import TestSettingPage from "@pages/test/TestSettingPage"; // /test/setting
 
 import { useAuthBootstrap } from "@hooks/useAuthBootstrap";
 import { useAuthStore } from "@store/authStore";
@@ -75,7 +76,7 @@ function KeyVerifyPlaceholder() {
     } catch (err: unknown) {
       const msg =
         typeof err === "object" && err && "message" in err
-          ? ((err as { message?: string }).message ?? "인증 실패")
+          ? (err as { message?: string }).message ?? "인증 실패"
           : "인증 실패";
       push({ message: msg, type: "error" });
     }
@@ -105,7 +106,9 @@ function KeyVerifyPlaceholder() {
           <div className="card-actions justify-end mt-2">
             <button
               type="submit"
-              className={`btn btn-primary ${verifyMut.isPending ? "loading" : ""}`}
+              className={`btn btn-primary ${
+                verifyMut.isPending ? "loading" : ""
+              }`}
               disabled={verifyMut.isPending}
             >
               {verifyMut.isPending ? "인증 중..." : "인증하기"}
@@ -185,6 +188,7 @@ export default function AppRouter() {
         {/* 테스트 라우트 */}
         <Route path={PATHS.ROOT} element={<TestHub />} />
         <Route path="/test/write" element={<TestPostWritePage />} />
+        <Route path="/test/setting" element={<TestSettingPage />} />
 
         {/* 인증 로비(공개) */}
         <Route path={PATHS.AUTH} element={<LandingPage />} />

--- a/src/utils/themeInit.ts
+++ b/src/utils/themeInit.ts
@@ -1,0 +1,15 @@
+// 웹 페이지 첫 로드 시 테마 초기화
+(function () {
+  try {
+    let theme = localStorage.getItem("theme");
+    if (!theme) {
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      theme = prefersDark ? "oz_dark" : "oz_light";
+    }
+    document.documentElement.setAttribute("data-theme", theme);
+  } catch (e) {
+    console.error("Failed to initialize theme", e);
+  }
+})();


### PR DESCRIPTION
### 사용자 설정 모달 UI 컴포넌트
- 닫힘 버튼 기능
- 라이트 모드 토글 기능
- 웹 로드 시 테마 초기화 기능
- 회원 인증 기능
- 회원 탈퇴 기능

### 참고 이미지
![001](https://github.com/user-attachments/assets/1638dace-b7ef-41d8-bf28-c7de7454d8c4)
![002](https://github.com/user-attachments/assets/308a08ff-a6e0-41f6-89ab-355a14ea0c6b)

### 사용 방법

```
  const [settingOpen, setSettingIsOpen] = useState<boolean>(false);
  const [theme, setTheme] = useState<"oz_dark" | "oz_light">("oz_dark");
  return (
    <SettingsPage
        isOpen={settingOpen}
        setIsOpen={setSettingIsOpen}
        theme={theme}
        setTheme={setTheme}
    />
    <ThemeInitializer setTheme={setTheme} />
  )
```

closes #29 