### PR TITLE
[feat] 테마 기반 아이콘 변경 훅 개발

### DIFF
--- a/src/hooks/useThemeIcon.ts
+++ b/src/hooks/useThemeIcon.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+type Theme = "oz_dark" | "oz_light";
+
+/** 테마 */
+export function useThemeIcon() {
+  const [theme, setTheme] = useState<Theme>("oz_dark");
+
+  useEffect(() => {
+    // 로컬스토리지 값 있으면 반영
+    const savedTheme = localStorage.getItem("theme") as Theme | null;
+    if (savedTheme) setTheme(savedTheme);
+
+    // data-theme 속성 변경 감지
+    const observer = new MutationObserver(() => {
+      const updatedTheme = document.documentElement.getAttribute(
+        "data-theme"
+      ) as Theme;
+      if (updatedTheme) setTheme(updatedTheme);
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}


### PR DESCRIPTION
### 테마 기반 아이콘 변경 훅
다크/라이트 테마에 따라 아이콘 스타일이 변경되도록 커스텀 훅을 개발했습니다.

### 예시 이미지
![1](https://github.com/user-attachments/assets/c5747d27-e21d-4e0e-ab3e-f97d3b2f3bed)

### Hook 사용 예시
```
import { icons } from "@src/assets";
import { useThemeIcon } from "@hooks/useThemeIcon";
import { useMemo } from "react";

export function 컴포넌트( ){
  const themeIcon = useThemeIcon();
  const { menuIcon, notificationsIcon } = useMemo(() => { // useMemo로 메모(불필요한 재계산 X)
    const dark = themeIcon === "oz_dark";
    return {
      menuIcon: dark ? icons.menu.dark : icons.menu.light,
      notificationsIcon: dark
        ? icons.notifications.dark
        : icons.notifications.light,
    };
  }, [themeIcon]);
  
  return (
    <>
      <img src={menuIcon} alt="menuIcon">
      <img src={notifications} alt="notifications">
    </>
```
closes #59 