### PR TITLE
[feat] Hot 게시글 컴포넌트 UI 구현

### DIFF
--- a/src/components/HotBoard/HotBoard.tsx
+++ b/src/components/HotBoard/HotBoard.tsx
@@ -1,0 +1,12 @@
+import { hotPosts } from "./data";
+import HotPostCard from "./HotPostCard";
+
+export default function HotBoard() {
+  return (
+    <div className="flex gap-2 w-[800px] h-[200px] py-2">
+      {hotPosts.map((post) => (
+        <HotPostCard key={post.id} post={post} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/HotBoard/HotBoard.tsx
+++ b/src/components/HotBoard/HotBoard.tsx
@@ -3,10 +3,13 @@ import HotPostCard from "./HotPostCard";
 
 export default function HotBoard() {
   return (
-    <div className="flex gap-2 w-[800px] h-[200px] py-2">
-      {hotPosts.map((post) => (
-        <HotPostCard key={post.id} post={post} />
-      ))}
+    <div>
+      <p className="py-2  text-base-content/50">Hot 게시판</p>
+      <div className="flex gap-2 w-[800px] h-[200px]">
+        {hotPosts.map((post) => (
+          <HotPostCard key={post.id} post={post} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/HotBoard/HotPostCard.tsx
+++ b/src/components/HotBoard/HotPostCard.tsx
@@ -1,0 +1,36 @@
+import { icons } from "@src/assets";
+import { useThemeIcon } from "@hooks/useThemeIcon";
+import { useMemo } from "react";
+import type { HotPost } from "./data";
+
+export default function HotPostCard({ post }: { post: HotPost }) {
+  const themeIcon = useThemeIcon();
+  const { thumbUp } = useMemo(() => {
+    const dark = themeIcon === "oz_dark";
+    return {
+      thumbUp: dark ? icons.thumbUp.dark : icons.thumbUp.light,
+    };
+  }, [themeIcon]);
+
+  return (
+    <button
+      className={`flex w-full h-[180px] rounded-lg shadow-md overflow-hidden border-2
+        hover:shadow-lg hover:scale-105 transition-all duration-200`}
+    >
+      <div className="flex flex-col justify-between p-2 flex-1 items-start text-left">
+        <div>
+          <p className={`text-sm mt-1 text-info/50`}>{post.board} 게시판</p>
+          <h3 className="text-lg font-semibold py-0.5 line-clamp-2">
+            {post.title}
+          </h3>
+        </div>
+        <div className="flex items-center justify-between text-sm w-full font-thin text-base-content/40">
+          <span>조회 {post.views}</span>
+          <div className="flex items-center gap-1">
+            <img src={thumbUp} alt="thumbUp" className="w-4 h-4" /> {post.likes}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/components/HotBoard/HotPostCard.tsx
+++ b/src/components/HotBoard/HotPostCard.tsx
@@ -2,6 +2,7 @@ import { icons } from "@src/assets";
 import { useThemeIcon } from "@hooks/useThemeIcon";
 import { useMemo } from "react";
 import type { HotPost } from "./data";
+import { CARD_STYLE, CARD_TEXT } from "./boardColor";
 
 export default function HotPostCard({ post }: { post: HotPost }) {
   const themeIcon = useThemeIcon();
@@ -15,11 +16,14 @@ export default function HotPostCard({ post }: { post: HotPost }) {
   return (
     <button
       className={`flex w-full h-[180px] rounded-lg shadow-md overflow-hidden border-2
+        ${CARD_STYLE[post.board]}
         hover:shadow-lg hover:scale-105 transition-all duration-200`}
     >
       <div className="flex flex-col justify-between p-2 flex-1 items-start text-left">
         <div>
-          <p className={`text-sm mt-1 text-info/50`}>{post.board} 게시판</p>
+          <p className={`text-sm mt-1 text-info/50 ${CARD_TEXT[post.board]}`}>
+            {post.board} 게시판
+          </p>
           <h3 className="text-lg font-semibold py-0.5 line-clamp-2">
             {post.title}
           </h3>

--- a/src/components/HotBoard/HotPostCard.tsx
+++ b/src/components/HotBoard/HotPostCard.tsx
@@ -21,7 +21,7 @@ export default function HotPostCard({ post }: { post: HotPost }) {
     >
       <div className="flex flex-col justify-between p-2 flex-1 items-start text-left">
         <div>
-          <p className={`text-sm mt-1 text-info/50 ${CARD_TEXT[post.board]}`}>
+          <p className={`text-sm mt-1 ${CARD_TEXT[post.board]}`}>
             {post.board} 게시판
           </p>
           <h3 className="text-lg font-semibold py-0.5 line-clamp-2">

--- a/src/components/HotBoard/boardColor.ts
+++ b/src/components/HotBoard/boardColor.ts
@@ -1,0 +1,16 @@
+export const CARD_STYLE: Record<string, string> = {
+  자유: "border-pink-500/30 bg-pink-500/5 hover:border-pink-500/70 hover:bg-pink-500/10",
+  취업: "border-green-500/30 bg-green-500/5 hover:border-green-500/70 hover:bg-green-500/10",
+  정보: "border-amber-500/30 bg-amber-500/5 hover:border-amber-500/70 hover:bg-amber-500/10",
+  설문: "border-blue-500/30 bg-blue-500/5 hover:border-blue-500/70 hover:bg-blue-500/10",
+  GitHub:
+    "border-purple-500/30 bg-purple-500/5 hover:border-purple-500/70 hover:bg-purple-500/10",
+};
+
+export const CARD_TEXT: Record<string, string> = {
+  자유: "text-pink-500/70",
+  취업: "text-green-500/70",
+  정보: "text-amber-500/70",
+  설문: "text-blue-500/70",
+  GitHub: "text-purple-500/70",
+};

--- a/src/components/HotBoard/data.ts
+++ b/src/components/HotBoard/data.ts
@@ -1,0 +1,45 @@
+export type HotPost = {
+  id: number;
+  title: string;
+  board: "자유" | "취업" | "정보" | "설문" | "GitHub";
+  views: number;
+  likes: number;
+};
+
+export const hotPosts: HotPost[] = [
+  {
+    id: 1,
+    title: "오늘 점심 뭐 먹지? 자유롭게 공유해요!",
+    board: "자유",
+    views: 1250,
+    likes: 87,
+  },
+  {
+    id: 2,
+    title: "이번 달 취업 공고 모음",
+    board: "취업",
+    views: 980,
+    likes: 65,
+  },
+  {
+    id: 3,
+    title: "Git 브랜치 전략 완전 정리",
+    board: "GitHub",
+    views: 1340,
+    likes: 102,
+  },
+  {
+    id: 4,
+    title: "웹 개발 관련 최신 정보 공유",
+    board: "정보",
+    views: 870,
+    likes: 42,
+  },
+  {
+    id: 5,
+    title: "팀원 설문 조사 참여해주세요",
+    board: "설문",
+    views: 1120,
+    likes: 78,
+  },
+];

--- a/src/pages/test/TestMainPage.tsx
+++ b/src/pages/test/TestMainPage.tsx
@@ -1,11 +1,15 @@
 import Sidebar from "@components/Sidebar/Sidebar";
+import HotBoard from "@src/components/HotBoard/HotBoard";
 
 export default function TestMainPage() {
   return (
-    <div className="flex">
+    <div className="relative flex w-full h-screen overflow-hidden">
       <Sidebar />
-      <div className="flex items-center justify-center w-9/12">
-        <div className="w-[820px] h-[900px] bg-base-200">메인이에용</div>
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex flex-col gap-2 items-center justify-center w-[820px] max-h-[900px]">
+          <div className="w-[800px] h-[180px] bg-base-200">취업배너</div>
+          <HotBoard />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 개요
카드 형태로 Hot 게시글을 표시하는 컴포넌트 UI를 구현

## 작업 항목
Hot 게시글 카드 UI 구현하여 각 카드에 게시글 데이터 반영 (제목, 게시판, 좋아요 등)

## 구현 이미지
<img width="812" height="1065" alt="image" src="https://github.com/user-attachments/assets/73bedf56-61c1-4abb-a458-c3623732f4dd" />

closes #65 