### PR TITLE
[feat] 메인 홈 레이아웃

### DIFF
--- a/src/pages/test/TestMainPage.tsx
+++ b/src/pages/test/TestMainPage.tsx
@@ -3,12 +3,15 @@ import HotBoard from "@src/components/HotBoard/HotBoard";
 
 export default function TestMainPage() {
   return (
-    <div className="relative flex w-full h-screen overflow-hidden">
+    <div className="flex w-full min-h-screen">
       <Sidebar />
-      <div className="flex-1 flex items-center justify-center">
-        <div className="flex flex-col gap-2 items-center justify-center w-[820px] max-h-[900px]">
+      <div className="flex-1 flex justify-center">
+        {/** 메인 페이지 */}
+        <div className="flex flex-col gap-2 items-center justify-center w-[820px] h-full">
+          <div className="w-[800px] h-[60px] bg-base-200 my-8"></div>
           <div className="w-[800px] h-[180px] bg-base-200">취업배너</div>
           <HotBoard />
+          <div className="w-[800px] h-[360px] bg-base-200 pb-8"></div>
         </div>
       </div>
     </div>

--- a/src/pages/test/TestMainPage.tsx
+++ b/src/pages/test/TestMainPage.tsx
@@ -1,8 +1,18 @@
 import Sidebar from "@components/Sidebar/Sidebar";
 import HotBoard from "@src/components/HotBoard/HotBoard";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function TestMainPage() {
+  const [showAd, setShowAd] = useState(false);
+
+  // 브라우저 창 너비를 감지해 광고 배너를 노출할지 결정
+  useEffect(() => {
+    const checkWidth = () => setShowAd(window.innerWidth >= 1600);
+    checkWidth();
+    window.addEventListener("resize", checkWidth);
+    return () => window.removeEventListener("resize", checkWidth);
+  }, []);
+
   // 페이지 로드 시 스크롤 막기
   useEffect(() => {
     document.body.style.overflow = "hidden";
@@ -22,6 +32,16 @@ export default function TestMainPage() {
           <HotBoard />
           <div className="w-[800px] h-[360px] bg-base-200 pb-8"></div>
         </div>
+
+        {/** 광고 배너 */}
+        {showAd && (
+          <div>
+            <div className="absolute right-10 top-20 w-[300px] h-[900px] bg-base-300 p-4">
+              광고 배너
+            </div>
+            <div className="w-[240px]"></div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/test/TestMainPage.tsx
+++ b/src/pages/test/TestMainPage.tsx
@@ -1,7 +1,16 @@
 import Sidebar from "@components/Sidebar/Sidebar";
 import HotBoard from "@src/components/HotBoard/HotBoard";
+import { useEffect } from "react";
 
 export default function TestMainPage() {
+  // 페이지 로드 시 스크롤 막기
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, []);
+
   return (
     <div className="flex w-full min-h-screen">
       <Sidebar />


### PR DESCRIPTION
## 개요
메인 홈을 반응형으로 레이아웃, 웹 스크롤 방지와 광고 배너를 보여줌

## 작업 내용 
- 메인 홈 레이아웃
- 웹 스크롤 방지
- 웹 너비에 따른 오즈 광고 배너를 노출

## 구현 이미지
<img width="2553" height="1262" alt="image" src="https://github.com/user-attachments/assets/4507eaff-0eff-48c2-8661-989386038305" />

<img width="1492" height="1263" alt="image" src="https://github.com/user-attachments/assets/e95b6a08-59d0-4e36-80d3-46e677dd7dc5" />

<img width="1182" height="1262" alt="image" src="https://github.com/user-attachments/assets/80a29345-340d-4677-b535-fcab65ec2654" />


closes #80