### PR TITLE
[feat] 게시글 목록 "본문" 내에서만 스크롤(무한 스크롤) 가능하도록 하기

### DIFF
--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -31,6 +31,8 @@ export type PostListProps = {
   empty?: EmptyStateProps;
 
   className?: string;
+
+  scrollRootRef?: (el: HTMLDivElement | null) => void; // 본문 스크롤
 };
 
 export default function PostList({
@@ -47,18 +49,20 @@ export default function PostList({
   noMoreText = "마지막 페이지입니다.",
   empty,
   className,
+  scrollRootRef,
 }: PostListProps) {
   const isEmpty = items.length === 0;
 
   return (
-    <section className={className ?? ""}>
+    // 섹션을 컬럼 레이아웃 + 높이 100% 로 만들고
+    <section className={`flex h-full flex-col ${className ?? ""}`}>
       {topBar && (
         <BoardTopBar
           boardName={topBar.boardName}
           onOpenSort={topBar.onOpenSort}
           onOpenTag={topBar.onOpenTag}
           onWrite={topBar.onWrite}
-          className="mb-2 px-3"
+          className="mb-2 px-3 flex-none"
           meta={
             <LastLoadedBar
               lastLoadedAt={lastLoadedAt}
@@ -70,7 +74,11 @@ export default function PostList({
         />
       )}
 
-      <div className="px-3">
+      {/* 본문만 스크롤되도록 */}
+      <div
+        ref={scrollRootRef}
+        className="px-3 flex-1 min-h-0 overflow-y-auto overscroll-contain"
+      >
         {isError && (
           <div className="py-10 text-center text-sm text-red-500">
             {errorText ?? "오류가 발생했습니다."}

--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -32,7 +32,7 @@ export type PostListProps = {
 
   className?: string;
 
-  scrollRootRef?: (el: HTMLDivElement | null) => void; // 본문 스크롤
+  scrollRootRef?: (el: HTMLDivElement | null) => void;
 };
 
 export default function PostList({

--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -96,7 +96,8 @@ export default function PostList({
             {/* 데스크톱(테이블) */}
             <div className="hidden md:block">
               <div
-                className={`${FREE_LIST_GRID} gap-2 py-2 text-xs font-medium text-base-content/60`}
+                className={`${FREE_LIST_GRID} gap-2 py-2 text-xs font-medium text-base-content/60 sticky top-0 z-10
+                bg-base-100 border-b border-base-300`}
               >
                 <div className="text-center">번호</div>
                 <div className="text-center">제목</div>

--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -54,7 +54,6 @@ export default function PostList({
   const isEmpty = items.length === 0;
 
   return (
-    // 섹션을 컬럼 레이아웃 + 높이 100% 로 만들고
     <section className={`flex h-full flex-col ${className ?? ""}`}>
       {topBar && (
         <BoardTopBar

--- a/src/components/Board/github/GithubList.tsx
+++ b/src/components/Board/github/GithubList.tsx
@@ -29,6 +29,8 @@ export type GithubListProps = {
   noMoreText?: string;
   emptyText?: string;
   className?: string;
+
+  scrollRootRef?: (el: HTMLDivElement | null) => void;
 };
 
 export default function GithubList({
@@ -46,18 +48,19 @@ export default function GithubList({
   noMoreText = "마지막 페이지입니다.",
   emptyText = "등록된 게시글이 없습니다.",
   className,
+  scrollRootRef,
 }: GithubListProps) {
   const isEmpty = items.length === 0;
 
   return (
-    <section className={className ?? ""}>
+    <section className={`flex h-full flex-col ${className ?? ""}`}>
       {topBar && (
         <BoardTopBar
           boardName={topBar.boardName}
           onOpenSort={topBar.onOpenSort}
           onOpenTag={topBar.onOpenTag}
           onWrite={topBar.onWrite}
-          className="mb-2 px-3"
+          className="mb-2 px-3 flex-none"
           meta={
             <LastLoadedBar
               lastLoadedAt={lastLoadedAt}
@@ -69,7 +72,10 @@ export default function GithubList({
         />
       )}
 
-      <div className="px-3">
+      <div
+        ref={scrollRootRef}
+        className="px-3 flex-1 min-h-0 overflow-y-auto overscroll-contain"
+      >
         {isError && (
           <div className="py-10 text-center text-sm text-red-500">
             {errorText ?? "오류가 발생했습니다."}

--- a/src/components/Board/survey/SurveyList.tsx
+++ b/src/components/Board/survey/SurveyList.tsx
@@ -28,6 +28,8 @@ export type SurveyListProps = {
   empty?: EmptyStateProps;
 
   className?: string;
+
+  scrollRootRef?: (el: HTMLDivElement | null) => void;
 };
 
 export default function SurveyList({
@@ -44,18 +46,19 @@ export default function SurveyList({
   noMoreText = "마지막 페이지입니다.",
   empty,
   className,
+  scrollRootRef,
 }: SurveyListProps) {
   const isEmpty = items.length === 0;
 
   return (
-    <section className={className ?? ""}>
+    <section className={`flex h-full flex-col ${className ?? ""}`}>
       {topBar && (
         <BoardTopBar
           boardName={topBar.boardName}
           onOpenSort={topBar.onOpenSort}
           onOpenTag={topBar.onOpenTag}
           onWrite={topBar.onWrite}
-          className="mb-2 px-3"
+          className="mb-2 px-3 flex-none"
           meta={
             <LastLoadedBar
               lastLoadedAt={lastLoadedAt}
@@ -67,7 +70,10 @@ export default function SurveyList({
         />
       )}
 
-      <div className="px-3">
+      <div
+        ref={scrollRootRef}
+        className="px-3 flex-1 min-h-0 overflow-y-auto overscroll-contain"
+      >
         {isError && (
           <div className="py-10 text-center text-sm text-red-500">
             {errorText ?? "오류가 발생했습니다."}

--- a/src/pages/test/BoardList/TestFreeBoardList.tsx
+++ b/src/pages/test/BoardList/TestFreeBoardList.tsx
@@ -45,6 +45,10 @@ export default function TestFreeBoardList() {
   const pageRef = useRef(1);
   const hasMoreRef = useRef(true);
 
+  // 본문 스크롤용
+  const scrollRootRef = useRef<HTMLDivElement | null>(null);
+  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
+
   useEffect(() => {
     return () => {
       mountedRef.current = false;
@@ -83,8 +87,8 @@ export default function TestFreeBoardList() {
   }, [page]);
 
   const { sentinelRef } = useInfiniteScroll({
-    root: null,
-    rootMargin: "1000px 0px",
+    root: rootEl,
+    rootMargin: "600px 0px",
     threshold: 0,
     disabled: busy || !hasMore || !!err, // 외부 가드
     onIntersect: loadMore,
@@ -135,7 +139,8 @@ export default function TestFreeBoardList() {
         </div>
       </header>
 
-      <section className="rounded-xl border p-3">
+      {/* ❗️ 본문 내 스크롤 적용 시 부모(wrapper)엔 높이가 있어야 함 ❗️ */}
+      <section className="rounded-xl border p-3 pb-8 h-[calc(100vh-100px)] overflow-hidden">
         <div className="text-xs opacity-70 mb-2">
           page: {page} / hasMore: {String(hasMore)} / busy: {String(busy)} /
           items: {items.length}
@@ -158,6 +163,10 @@ export default function TestFreeBoardList() {
           errorText={err ?? undefined}
           hasMore={hasMore}
           sentinelRef={sentinelRef}
+          scrollRootRef={(el) => {
+            scrollRootRef.current = el;
+            setRootEl(el);
+          }}
           empty={{
             message: "조건에 맞는 게시글이 없습니다.",
             actionLabel: "초기화",

--- a/src/pages/test/BoardList/TestFreeBoardList.tsx
+++ b/src/pages/test/BoardList/TestFreeBoardList.tsx
@@ -45,8 +45,6 @@ export default function TestFreeBoardList() {
   const pageRef = useRef(1);
   const hasMoreRef = useRef(true);
 
-  // 본문 스크롤용
-  const scrollRootRef = useRef<HTMLDivElement | null>(null);
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -163,10 +161,7 @@ export default function TestFreeBoardList() {
           errorText={err ?? undefined}
           hasMore={hasMore}
           sentinelRef={sentinelRef}
-          scrollRootRef={(el) => {
-            scrollRootRef.current = el;
-            setRootEl(el);
-          }}
+          scrollRootRef={setRootEl}
           empty={{
             message: "조건에 맞는 게시글이 없습니다.",
             actionLabel: "초기화",

--- a/src/pages/test/BoardList/TestGithubList.tsx
+++ b/src/pages/test/BoardList/TestGithubList.tsx
@@ -17,6 +17,8 @@ export default function TestGithubList() {
   );
   const [forcedError, setForcedError] = useState<string | null>(null);
 
+  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
+
   const {
     data,
     fetchNextPage,
@@ -32,8 +34,8 @@ export default function TestGithubList() {
 
   // 센티넬
   const { sentinelRef } = useInfiniteScroll({
-    root: null,
-    rootMargin: "1000px 0px",
+    root: rootEl,
+    rootMargin: "600px 0px",
     threshold: 0,
     disabled: isFetchingNextPage || !hasNextPage || !!forcedError || isError,
     onIntersect: async () => {
@@ -112,7 +114,8 @@ export default function TestGithubList() {
         </div>
       </header>
 
-      <section className="rounded-xl border p-3">
+      {/* ❗️ 본문 내 스크롤 적용 시 부모(wrapper)엔 높이가 있어야 함 ❗️ */}
+      <section className="rounded-xl border p-3 pb-8 h-[calc(100vh-100px)] overflow-hidden">
         <div className="text-xs opacity-70 mb-2">
           {debugText}
           {(isError || !!forcedError) && (
@@ -131,6 +134,7 @@ export default function TestGithubList() {
           errorText={forcedError ?? (error as Error)?.message}
           hasMore={!!hasNextPage}
           sentinelRef={sentinelRef}
+          scrollRootRef={setRootEl}
         />
       </section>
     </div>

--- a/src/pages/test/BoardList/TestGithubList.tsx
+++ b/src/pages/test/BoardList/TestGithubList.tsx
@@ -127,6 +127,7 @@ export default function TestGithubList() {
 
         <GithubList
           items={items}
+          onItemClick={(id) => console.log("go detail:", id)}
           topBar={{
             boardName: "GitHub 게시판",
             onOpenSort: () => console.log("정렬 필터 열기"),

--- a/src/pages/test/BoardList/TestGithubList.tsx
+++ b/src/pages/test/BoardList/TestGithubList.tsx
@@ -127,6 +127,12 @@ export default function TestGithubList() {
 
         <GithubList
           items={items}
+          topBar={{
+            boardName: "GitHub 게시판",
+            onOpenSort: () => console.log("정렬 필터 열기"),
+            onOpenTag: () => console.log("태그 필터 열기"),
+            onWrite: () => console.log("글쓰기 이동"),
+          }}
           lastLoadedAt={lastLoadedAt}
           onRefresh={handleRefresh}
           isLoading={isFetchingNextPage}

--- a/src/pages/test/BoardList/TestSurveyList.tsx
+++ b/src/pages/test/BoardList/TestSurveyList.tsx
@@ -32,9 +32,11 @@ export default function TestSurveyList() {
     [data]
   );
 
+  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
+
   const { sentinelRef } = useInfiniteScroll({
-    root: null,
-    rootMargin: "1000px 0px",
+    root: rootEl,
+    rootMargin: "600px 0px",
     threshold: 0,
     disabled: isFetchingNextPage || !hasNextPage || !!forcedError || isError,
     onIntersect: async () => {
@@ -98,7 +100,7 @@ export default function TestSurveyList() {
         </div>
       </header>
 
-      <section className="rounded-xl border p-3">
+      <section className="rounded-xl border p-3 pb-8 h-[calc(100vh-100px)] overflow-hidden">
         <div className="text-xs opacity-70 mb-2">
           hasMore: {String(!!hasNextPage)} / busy: {String(isFetchingNextPage)}{" "}
           / items: {items.length}
@@ -125,6 +127,7 @@ export default function TestSurveyList() {
           errorText={forcedError ?? (error as Error)?.message}
           hasMore={!!hasNextPage}
           sentinelRef={sentinelRef}
+          scrollRootRef={setRootEl}
           empty={{ message: "등록된 설문이 없습니다." }}
         />
       </section>

--- a/src/pages/test/BoardList/TestSurveyList.tsx
+++ b/src/pages/test/BoardList/TestSurveyList.tsx
@@ -100,6 +100,7 @@ export default function TestSurveyList() {
         </div>
       </header>
 
+      {/* ❗️ 본문 내 스크롤 적용 시 부모(wrapper)엔 높이가 있어야 함 ❗️ */}
       <section className="rounded-xl border p-3 pb-8 h-[calc(100vh-100px)] overflow-hidden">
         <div className="text-xs opacity-70 mb-2">
           hasMore: {String(!!hasNextPage)} / busy: {String(isFetchingNextPage)}{" "}


### PR DESCRIPTION
# 작업 사항
헤더 고정, 세 개 게시판 컴포넌트 목록 내 스크롤 구현
연관 이슈 #83

---
<img width="890" height="596" alt="image" src="https://github.com/user-attachments/assets/762a7262-df3a-4beb-8a93-e4ef2c510b75" />
<img width="905" height="697" alt="image" src="https://github.com/user-attachments/assets/74713f30-8254-47e2-b52b-29a074b4090e" />
<img width="970" height="695" alt="image" src="https://github.com/user-attachments/assets/747e1d56-b0e8-4e88-86f9-dd7c83f0436c" />

---

closes #83 