### PR TITLE
 [feat] 게시글 상세, 작성, 수정 라우트 설정

### DIFF
--- a/src/components/Board/WritePostPage.tsx
+++ b/src/components/Board/WritePostPage.tsx
@@ -1,14 +1,12 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import SharedPostForm from "./SharedPostForm";
 import SurveyPostForm from "./SurveyPostForm";
 import GitRepoPostForm from "./GithubPostForm";
-// import { createPost } from "@/api/post"; // 게시글 생성 API 추후 등록
-// import { Button } from "@/components/ui/button"; // 버튼 컴포넌트 (Tailwind 기반)
 
 const boardOptions = [
   { value: "free", label: "자유 게시판" },
-  { value: "job", label: "취업 게시판" },
+  { value: "jobs", label: "취업 게시판" },
   { value: "info", label: "정보 게시판" },
   { value: "survey", label: "설문 게시판" },
   { value: "github", label: "GitHub 게시판" },
@@ -17,6 +15,21 @@ const boardOptions = [
 const WritePostPage = () => {
   const navigate = useNavigate();
   const [selectedBoard, setSelectedBoard] = useState("free");
+
+  // 쿼리 헬퍼
+  const [sp, setSp] = useSearchParams();
+  const setBoardQuery = (value: string | undefined) => {
+    const next = new URLSearchParams(sp);
+    if (value) next.set("board", value);
+    else next.delete("board");
+    setSp(next, { replace: true });
+  };
+
+  // 첫 렌더 시 URL에 board 없으면 기본값 반영(free)
+  useEffect(() => {
+    if (!sp.get("board")) setBoardQuery("free");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="flex flex-col h-full max-w-4xl mx-auto px-4 py-8 gap-2 text-black">
@@ -32,7 +45,11 @@ const WritePostPage = () => {
           id="board-select"
           className="w-full border border-gray-300 rounded p-2"
           value={selectedBoard}
-          onChange={(e) => setSelectedBoard(e.target.value)}
+          onChange={(e) => {
+            const v = e.target.value;
+            setSelectedBoard(v); // 기존 state 그대로 유지
+            setBoardQuery(v); // URL ?board= 동기화
+          }}
         >
           {boardOptions.map((option) => (
             <option key={option.value} value={option.value}>
@@ -42,7 +59,7 @@ const WritePostPage = () => {
         </select>
       </div>
 
-      {/* 2. 폼 스위칭 */}
+      {/* 2. 폼 스위칭 (그대로) */}
       {selectedBoard === "survey" ? (
         <SurveyPostForm onCancel={() => navigate(-1)} />
       ) : selectedBoard === "github" ? (

--- a/src/components/Post/PostDetail.tsx
+++ b/src/components/Post/PostDetail.tsx
@@ -26,6 +26,8 @@ import { profileToTagsMock } from "@src/mocks/tags.mock";
 import AssignedTagList from "../tags/AssignedTagList";
 import { RepoPreviewCard } from "../Board/RepoPreviewCard";
 import LinkPreviewCard from "../Board/LinkPreviewCard";
+import { useNavigate } from "react-router-dom";
+import { urlForPost } from "@src/utils/urlForPost";
 
 // ================== Main ==================
 export default function PostDetail({ post }: { post: PostMeta }) {
@@ -36,6 +38,8 @@ export default function PostDetail({ post }: { post: PostMeta }) {
   const [submitting, setSubmitting] = useState(false);
 
   const [comments, setComments] = useState<CommentMeta[]>(() => demoComments);
+
+  const navigate = useNavigate();
 
   const reaction = useMemo(
     () => ({
@@ -125,6 +129,7 @@ export default function PostDetail({ post }: { post: PostMeta }) {
         icon: <Pencil className="h-4 w-4" />,
         onSelect: () => {
           // TODO: 수정 페이지 이동
+          navigate(urlForPost.postEdit(String(post.id))); // UI 테스트 연결용
         },
       },
       {

--- a/src/constants/boards.ts
+++ b/src/constants/boards.ts
@@ -1,0 +1,33 @@
+export type BoardKey = "free" | "jobs" | "info" | "survey" | "github";
+
+/** 서버 board id ↔ FE board key 매핑 */
+export const BOARD_ID_TO_KEY: Record<number, BoardKey> = {
+  1: "free",
+  2: "jobs",
+  3: "info",
+  4: "survey",
+  5: "github",
+};
+
+/** 서버 board id ↔ FE board key 매핑 */
+export const BOARD_KEY_TO_ID: Record<BoardKey, number> = {
+  free: 1,
+  jobs: 2,
+  info: 3,
+  survey: 4,
+  github: 5,
+};
+
+/** 쿼리 파라미터 키(규약) */
+export const BOARD_QUERY_KEY = "board" as const;
+
+/** 타입 가드 */
+export function isBoardKey(v?: string | null): v is BoardKey {
+  return (
+    v === "free" ||
+    v === "jobs" ||
+    v === "info" ||
+    v === "survey" ||
+    v === "github"
+  );
+}

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -12,6 +12,11 @@ export const PATHS = {
   SURVEY_BOARD: "/board/survey",
   GITHUB_BOARD: "/board/github",
 
+  // 게시글
+  POST_DETAIL: "/board/:board/post/:id",
+  POST_CREATE: "/write", // 쿼리로 board 구분
+  POST_EDIT: "/post/:id/edit",
+
   // 마이페이지 관련 경로 추가
   MYPAGE: "/mypage",
   MYPAGE_POSTS: "/mypage/posts",

--- a/src/pages/test/BoardList/TestFreeBoardList.tsx
+++ b/src/pages/test/BoardList/TestFreeBoardList.tsx
@@ -3,6 +3,8 @@ import PostList from "@components/Board/free/PostList";
 import type { FreeBoardItem } from "@components/Board/free/PostRow";
 import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
 import { formatYyMmDd, formatYyyyMmDdHms } from "@utils/date";
+import { urlForPost } from "@utils/urlForPost";
+import { useNavigate } from "react-router-dom";
 
 const PAGE_SIZE = 15;
 const MAX_PAGES = 4;
@@ -30,6 +32,10 @@ function makeMockItems(count: number, startIndex: number): FreeBoardItem[] {
 }
 
 export default function TestFreeBoardList() {
+  const navigate = useNavigate();
+
+  const currentBoard: "free" | "jobs" | "info" = "free";
+
   const [page, setPage] = useState(1);
   const [items, setItems] = useState<FreeBoardItem[]>(() =>
     makeMockItems(PAGE_SIZE, 0)
@@ -147,12 +153,12 @@ export default function TestFreeBoardList() {
 
         <PostList
           items={items}
-          onItemClick={(id) => console.log("go detail:", id)}
+          onItemClick={(id) => navigate(urlForPost.postDetail("free", id))} // id에 해당하는 게시글 상세 페이지로
           topBar={{
             boardName: "자유 게시판",
             onOpenSort: () => console.log("정렬 필터 열기"),
             onOpenTag: () => console.log("태그 필터 열기"),
-            onWrite: () => console.log("글쓰기 이동"),
+            onWrite: () => navigate(urlForPost.postCreate(currentBoard)), // 자유게시판으로 설정해둠
           }}
           lastLoadedAt={lastLoadedAt}
           onRefresh={handleRefresh}

--- a/src/pages/test/BoardList/TestGithubList.tsx
+++ b/src/pages/test/BoardList/TestGithubList.tsx
@@ -9,8 +9,12 @@ import {
 import GithubList from "@components/Board/github/GithubList";
 import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
 import { formatYyyyMmDdHms } from "@utils/date";
+import { useNavigate } from "react-router-dom";
+import { urlForPost } from "@src/utils/urlForPost";
 
 export default function TestGithubList() {
+  const navigate = useNavigate();
+
   const qc = useQueryClient();
   const [lastLoadedAt, setLastLoadedAt] = useState(
     formatYyyyMmDdHms(new Date())
@@ -127,12 +131,12 @@ export default function TestGithubList() {
 
         <GithubList
           items={items}
-          onItemClick={(id) => console.log("go detail:", id)}
+          onItemClick={(id) => navigate(urlForPost.postDetail("github", id))}
           topBar={{
             boardName: "GitHub 게시판",
             onOpenSort: () => console.log("정렬 필터 열기"),
             onOpenTag: () => console.log("태그 필터 열기"),
-            onWrite: () => console.log("글쓰기 이동"),
+            onWrite: () => navigate(urlForPost.postCreate("github")),
           }}
           lastLoadedAt={lastLoadedAt}
           onRefresh={handleRefresh}

--- a/src/pages/test/BoardList/TestSurveyList.tsx
+++ b/src/pages/test/BoardList/TestSurveyList.tsx
@@ -5,11 +5,15 @@ import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
 import { formatYyyyMmDdHms } from "@utils/date";
 import { useSurveysMock } from "@hooks/useSurveys.mock";
 import type { SurveyCardProps } from "@components/Board/survey/SurveyCard";
+import { useNavigate } from "react-router-dom";
+import { urlForPost } from "@src/utils/urlForPost";
 
 type Page = { items: SurveyCardProps[]; hasMore: boolean };
 const SURVEYS_MOCK_KEY = ["surveys-mock"] as const;
 
 export default function TestSurveyList() {
+  const navigate = useNavigate();
+
   const qc = useQueryClient();
   const [lastLoadedAt, setLastLoadedAt] = useState(
     formatYyyyMmDdHms(new Date())
@@ -114,12 +118,12 @@ export default function TestSurveyList() {
 
         <SurveyList
           items={items}
-          onItemClick={(id) => console.log("go detail:", id)}
+          onItemClick={(id) => navigate(urlForPost.postDetail("survey", id))}
           topBar={{
             boardName: "설문 게시판",
             onOpenSort: () => console.log("정렬 필터 열기"),
             onOpenTag: () => console.log("태그 필터 열기"),
-            onWrite: () => console.log("글쓰기 이동"),
+            onWrite: () => navigate(urlForPost.postCreate("survey")),
           }}
           lastLoadedAt={lastLoadedAt}
           onRefresh={handleRefresh}

--- a/src/utils/urlForPost.ts
+++ b/src/utils/urlForPost.ts
@@ -1,0 +1,14 @@
+export const urlForPost = {
+  /** 상세: /board/:board/post/:id */
+  postDetail: (
+    board: "free" | "jobs" | "info" | "survey" | "github",
+    id: string | number
+  ) => `/board/${board}/post/${id}`,
+
+  /** 작성: /write?board=... (board 없으면 /write) */
+  postCreate: (board?: "free" | "jobs" | "info" | "survey" | "github") =>
+    board ? `/write?board=${board}` : `/write`,
+
+  /** 수정: /post/:id/edit */
+  postEdit: (id: string | number) => `/post/${id}/edit`,
+} as const;


### PR DESCRIPTION
API 문서를 참고하여 게시글 상세, 작성, 수정 페이지의 라우트를 설정했습니다.
현재 UI 연결 단계로, API 로직 관련은 추후 추가합니다.

컴포넌트 연결은 후속 이슈에서 작업합니다.

연관 이슈 #106 

# urlForPost.ts 사용법
`utils/urlForPost.ts` 에 UI 연결용 라우트 경로 만드는 로직이 들어있습니다.
아래와 같이 작동하게 하면 희망 경로로 라우트 됩니다.

### 게시글 작성
`navigate(urlForPost.postCreate("{게시판 종류}")`

### 게시글 수정
`navigate(urlForPost.postEdit({게시글 id})`

### 게시글 상세
`navigate(urlForPost.postDetail("{게시판 종류}", {게시글 id})`

---

closes #106 