### PR TITLE
[feat] 메인 레이아웃에 마이페이지 추가

### DIFF
--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -17,11 +17,11 @@ export const PATHS = {
   POST_CREATE: "/write", // 쿼리로 board 구분
   POST_EDIT: "/post/:id/edit",
 
-  // 마이페이지 관련 경로 추가
+  // 마이페이지 (중첩 라우팅으로 상대 경로 설정)
   MYPAGE: "/mypage",
-  MYPAGE_POSTS: "/mypage/posts",
-  MYPAGE_COMMENTS: "/mypage/comments",
-  MYPAGE_BOOKMARKS: "/mypage/bookmarks",
+  MYPAGE_POSTS: "posts",
+  MYPAGE_COMMENTS: "comments",
+  MYPAGE_BOOKMARKS: "bookmarks",
 
   ERROR_403: "/403",
   ERROR_404: "/404",

--- a/src/pages/mypage/MyPageMain.tsx
+++ b/src/pages/mypage/MyPageMain.tsx
@@ -327,19 +327,18 @@ const MyPageMain: React.FC = () => {
             />
           ))}
         </div>
-      </div>
 
-      {/* ✅ setTimeout 제거: onAnimationEnd 이벤트로 안정적 네비게이션 */}
-      {isExpanding && (
-        <div
-          className="fixed inset-0 bg-base-100 z-30"
-          style={{
-            animation: `expandFromCenter ${ANIMATION_TIMINGS.CARD_EXPAND}ms cubic-bezier(0.4, 0, 0.2, 1) forwards`,
-            clipPath: "polygon(50% 0%, 50% 0%, 50% 100%, 50% 100%)",
-          }}
-          onAnimationEnd={handleOverlayAnimationEnd}
-        />
-      )}
+        {isExpanding && (
+          <div
+            className="absolute inset-0 bg-base-100 z-30"
+            style={{
+              animation: `expandFromCenter ${ANIMATION_TIMINGS.CARD_EXPAND}ms cubic-bezier(0.4, 0, 0.2, 1) forwards`,
+              clipPath: "polygon(50% 0%, 50% 0%, 50% 100%, 50% 100%)",
+            }}
+            onAnimationEnd={handleOverlayAnimationEnd}
+          />
+        )}
+      </div>
 
       {/* 공통 애니메이션 스타일 사용 */}
       {React.createElement("style", {

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -263,26 +263,6 @@ export default function AppRouter() {
         {/* 인증 로비(공개) */}
         <Route path={PATHS.AUTH} element={<LandingPage />} />
 
-        {/* 보호: 마이페이지 (JWT + 인증 완료) */}
-        <Route
-          path={PATHS.MYPAGE}
-          element={
-            isAuthed && isOzAuthenticated === true ? (
-              <MyPageLayout />
-            ) : isAuthed && isOzAuthenticated === false ? (
-              <Navigate to={PATHS.KEY_VERIFY} replace />
-            ) : (
-              redirectWithIntent(PATHS.AUTH, location)
-            )
-          }
-        >
-          {/* 마이페이지 중첩 라우팅 */}
-          <Route index element={<MyPageMain />} />
-          <Route path="posts" element={<MyPosts />} />
-          <Route path="comments" element={<MyComments />} />
-          <Route path="bookmarks" element={<MyBookmarks />} />
-        </Route>
-
         {/* 보호: /key-verify (JWT + 미인증) */}
         <Route
           path={PATHS.KEY_VERIFY}
@@ -297,7 +277,7 @@ export default function AppRouter() {
           }
         />
 
-        {/* 메인 페이지 + 게시글 포함 */}
+        {/* 메인 페이지 + 게시글 + 마이페이지 */}
         <Route element={<MainLayout />}>
           <Route path={PATHS.MAIN} element={<MainPage />} />
           <Route
@@ -319,7 +299,27 @@ export default function AppRouter() {
 
           <Route path={PATHS.GITHUB_BOARD} element={<TestGithubList />} />
           <Route path={PATHS.POST_CREATE} element={<WritePostPage />} />
-          <Route path={PATHS.POST_DETAIL} element={<PostDetailPage />}></Route>
+          <Route path={PATHS.POST_DETAIL} element={<PostDetailPage />} />
+
+          {/* 보호: 마이페이지 (JWT + 인증 완료) */}
+          <Route
+            path={PATHS.MYPAGE}
+            element={
+              isAuthed && isOzAuthenticated === true ? (
+                <MyPageLayout />
+              ) : isAuthed && isOzAuthenticated === false ? (
+                <Navigate to={PATHS.KEY_VERIFY} replace />
+              ) : (
+                redirectWithIntent(PATHS.AUTH, location)
+              )
+            }
+          >
+            {/* 마이페이지 중첩 라우팅 */}
+            <Route index element={<MyPageMain />} />
+            <Route path={PATHS.MYPAGE_POSTS} element={<MyPosts />} />
+            <Route path={PATHS.MYPAGE_COMMENTS} element={<MyComments />} />
+            <Route path={PATHS.MYPAGE_BOOKMARKS} element={<MyBookmarks />} />
+          </Route>
         </Route>
 
         {/* 에러 */}


### PR DESCRIPTION
## 변경 사항
- 메인 레이아웃 안에 마이페이지 라우트를 추가했습니다.
- 마이페이지가 중첩 라우팅으로 설정되어 있어, 이에 맞게 관련 경로 상수명을 수정했습니다.
- 작성글, 작성댓글, 북마크 탭 클릭 시의 화면 전환 애니메이션이 기존에는 웹 전체에 표시되던 문제를 수정하여, 이제 마이페이지 컨테이너 내부에서만 작동하도록 변경했습니다.