### PR TITLE
[feat] 깃허브 게시판 목록 페이지 생성 및 API, 라우트 연결

### DIFF
--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -1,0 +1,49 @@
+import api from "@api/client";
+import { BOARD_ID } from "@constants/boards";
+import type { PostListItem } from "@api/posts";
+
+export type GithubDetailResponse = { post_id?: number | string; link?: string };
+
+/** GitHub 게시글 상세(링크만 필요) */
+export async function fetchGithubLinkById(postId: string): Promise<string> {
+  const { data } = await api.get<GithubDetailResponse>(
+    `/api/posts/github/${postId}`
+  );
+  return typeof data.link === "string" ? data.link : "";
+}
+
+/** GitHub 게시판 목록 1페이지(페이지네이션 정보 포함) */
+export async function fetchGithubListPage(params: {
+  page: number;
+  page_size: number;
+  ordering?: "-created_at" | "created_at" | "-view_count" | "view_count";
+}): Promise<{ items: PostListItem[]; hasNext: boolean }> {
+  const { page, page_size, ordering = "-created_at" } = params;
+
+  const { data } = await api.get<
+    | {
+        results?: PostListItem[];
+        next?: string | null;
+        previous?: string | null;
+        count?: number;
+      }
+    | PostListItem[]
+  >("/api/posts/", {
+    params: {
+      board: BOARD_ID.github, // ← 슬러그 매핑은 상수에서
+      page,
+      page_size,
+      ordering,
+    },
+  });
+
+  // DRF 표준: {count, next, previous, results}
+  if (Array.isArray(data)) {
+    // 백엔드가 배열로만 줄 수도 있음 → 다음 페이지 정보 없음
+    return { items: data, hasNext: data.length === page_size };
+  }
+
+  const items = Array.isArray(data?.results) ? data.results : [];
+  const hasNext = Boolean(data?.next); // ← “다음 페이지 존재 여부”를 API 레이어에서 결정
+  return { items, hasNext };
+}

--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -3,7 +3,7 @@ import EmptyState, {
   type EmptyStateProps,
 } from "@components/Board/common/EmptyState";
 import PostRow, { type FreeBoardItem, FREE_LIST_GRID } from "./PostRow";
-import PostCard from "./PostCard";
+// import PostCard from "./PostCard";
 import { LastLoadedBar, BoardTopBar } from "../common";
 import { useRef, useState, type ReactNode } from "react";
 import SortRadioPopover from "@components/Board/common/sort/SortRadioPopover";
@@ -113,7 +113,8 @@ export default function PostList({
         {!isError && !(isLoading && isEmpty) && !isEmpty && (
           <>
             {/* 데스크톱(테이블) — 작성자 라인을 텍스트로 대체 */}
-            <div className="hidden md:block">
+            {/* 반응형 추가시 아래 div className="hidden md:block" 로 교체 */}
+            <div className="block">
               <div
                 className={`${FREE_LIST_GRID} gap-2 py-2 text-xs font-medium text-base-content/60 sticky top-0 z-10 bg-base-100 border-b border-base-300`}
               >
@@ -138,8 +139,8 @@ export default function PostList({
               </ul>
             </div>
 
-            {/* 모바일(카드) — 작성자 라인을 텍스트로 대체 */}
-            <div className="md:hidden">
+            {/* (통일감 위해 반응형 제거) 모바일(카드) — 작성자 라인을 텍스트로 대체 */}
+            {/* <div className="md:hidden">
               <ul className="space-y-2 max-[360px]:space-y-1.5">
                 {items.map((it) => (
                   <li key={String(it.id)}>
@@ -151,7 +152,7 @@ export default function PostList({
                   </li>
                 ))}
               </ul>
-            </div>
+            </div> */}
 
             {/* 센티넬 */}
             <div className="mt-2">

--- a/src/features/posts/list/githubAdapter.tsx
+++ b/src/features/posts/list/githubAdapter.tsx
@@ -1,0 +1,56 @@
+import AssignedTagList from "@components/tags/AssignedTagList";
+import type { GithubListItem } from "@components/Board/github/GithubList";
+import type { PostListItem } from "@api/posts";
+import { profileToTagsMock } from "@src/mocks/tags.mock";
+
+type AnyObj = Record<string, unknown>;
+function isObj(v: unknown): v is AnyObj {
+  return typeof v === "object" && v !== null;
+}
+function pickString(o: unknown, key: string): string | undefined {
+  if (!isObj(o)) return undefined;
+  const v = o[key];
+  return typeof v === "string" ? v : undefined;
+}
+function pickNestedString(
+  o: unknown,
+  path: readonly string[]
+): string | undefined {
+  let cur: unknown = o;
+  for (const k of path) {
+    if (!isObj(cur)) return undefined;
+    cur = cur[k];
+  }
+  return typeof cur === "string" ? cur : undefined;
+}
+
+/** PostListItem -> GithubListItem (link/태그는 가드 기반으로 안전 접근) */
+export function mapToGithubListItem(src: PostListItem): GithubListItem {
+  const title = (src as PostListItem).title ?? "(제목 없음)";
+
+  const content = pickString(src, "content");
+  const excerpt =
+    pickString(src, "excerpt") ??
+    (typeof content === "string"
+      ? content.replace(/\s+/g, " ").slice(0, 80)
+      : "");
+
+  // 목록 응답에 link가 없을 수 있음(상세로 보강)
+  const repoLink = pickString(src, "link") ?? "";
+
+  // TODO: 작성자 태그: API 확정 전까지 안전 접근 + 목 태그
+  const cohort = pickNestedString(src, ["user", "cohort"]) ?? "11기";
+  const position = pickNestedString(src, ["user", "position"]) ?? "프론트";
+  const tags = profileToTagsMock(
+    cohort as Parameters<typeof profileToTagsMock>[0],
+    position as Parameters<typeof profileToTagsMock>[1]
+  );
+
+  return {
+    id: String((src as PostListItem).id),
+    title,
+    excerpt,
+    repoLink,
+    tagSlot: <AssignedTagList tags={tags} />,
+  };
+}

--- a/src/hooks/useGithubPosts.ts
+++ b/src/hooks/useGithubPosts.ts
@@ -4,48 +4,92 @@ import type { GithubListItem } from "@components/Board/github/GithubList";
 import type { PostListItem } from "@api/posts";
 import { fetchGithubLinkById, fetchGithubListPage } from "@api/github";
 import { mapToGithubListItem } from "@src/features/posts/list/githubAdapter";
-import { LIST_SETTINGS } from "@src/constants/ui";
 
-const GITHUB_BOARD_SLUG = "github" as const; // 키에만 사용 (표시용)
-const PAGE_SIZE = LIST_SETTINGS.ITEMS_PER_PAGE;
+// NOTE: 키 표시에만 사용 (API 파라미터는 github.ts에서 board id 사용)
+const GITHUB_BOARD_SLUG = "github" as const;
+
+// ---------------------------
+// TODO(sort): UI의 SortValue ↔ API ordering 매핑 표
+// useBoardPosts와 동일한 규약 유지
+export type SortValue = "latest" | "oldest" | "mostViewed" | "leastViewed";
+function toOrdering(
+  v: SortValue | undefined
+): "-created_at" | "created_at" | "-view_count" | "view_count" | undefined {
+  switch (v) {
+    case "latest":
+      return "-created_at";
+    case "oldest":
+      return "created_at";
+    case "mostViewed":
+      return "-view_count";
+    case "leastViewed":
+      return "view_count";
+    default:
+      return undefined;
+  }
+}
+// ---------------------------
+
+// 훅 옵션(현재는 전부 optional, 미지정 시 현행 동작 유지)
+// TODO(filter): 태그/검색/정렬 연결 시 PostListPage, useBoardPosts와 동일 시그니처로 확장
+export type UseGithubPostsOptions = {
+  pageSize?: number; // default 10
+  sort?: SortValue; // default 'latest'
+  search?: string; // 검색어
+  tagIds?: number[]; // TODO(tags): 서버 태그 필터 파라미터 키 확인 후 적용
+};
+
+const DEFAULT_PAGE_SIZE = 10;
 
 type GithubPostsPage = { items: PostListItem[]; hasNext: boolean };
 
-async function fetchGithubPage(page: number): Promise<GithubPostsPage> {
-  // 다음 페이지 존재 여부는 API 레이어가 판단
+async function fetchGithubPage(
+  page: number,
+  opt?: UseGithubPostsOptions
+): Promise<GithubPostsPage> {
+  // API 레이어가 hasNext를 판단 (next 존재 유무)
   return fetchGithubListPage({
     page,
-    page_size: PAGE_SIZE,
-    ordering: "-created_at",
+    page_size: opt?.pageSize ?? DEFAULT_PAGE_SIZE,
+    ordering: toOrdering(opt?.sort) ?? "-created_at",
+    // TODO(filter): search/tagIds 전달 (백엔드 파라미터 키 확정되면 아래 주석 해제)
+    // search: opt?.search,
+    // tags: opt?.tagIds,
   });
 }
 
-export const GITHUB_POSTS_KEY = [
-  "github-posts",
-  { board: GITHUB_BOARD_SLUG, pageSize: PAGE_SIZE, ordering: "-created_at" },
-] as const;
+export function useGithubPosts(opt?: UseGithubPostsOptions) {
+  const pageSize = opt?.pageSize ?? DEFAULT_PAGE_SIZE;
+  const ordering = toOrdering(opt?.sort) ?? "-created_at";
 
-export function useGithubPosts() {
   return useInfiniteQuery({
-    queryKey: GITHUB_POSTS_KEY,
+    // ⚠️ 키에 옵션 포함 (정렬/필터 변경 시 캐시 분리)
+    queryKey: [
+      "github-posts",
+      {
+        board: GITHUB_BOARD_SLUG,
+        pageSize,
+        ordering,
+        search: opt?.search,
+        tags: opt?.tagIds,
+      },
+    ] as const,
     initialPageParam: 1,
-    queryFn: ({ pageParam }) => fetchGithubPage(pageParam as number),
+    queryFn: ({ pageParam }) => fetchGithubPage(pageParam as number, opt),
     getNextPageParam: (lastPage, pages, lastParam) => {
-      // ✅ API 레이어가 알려준 hasNext만 신뢰
       if (!lastPage.hasNext) return undefined;
 
-      // 안전 가드: 서버가 같은 페이지를 반복으로 주는 경우 차단
+      // 안전 가드: 같은 페이지 반복 방지
       const prev = pages[pages.length - 2] as GithubPostsPage | undefined;
       if (prev) {
         const a = prev.items.map((p) => p.id);
         const b = lastPage.items.map((p) => p.id);
-        if (a.length === b.length && a.every((v, i) => v === b[i])) {
+        if (a.length === b.length && a.every((v, i) => v === b[i]))
           return undefined;
-        }
       }
       return (lastParam as number) + 1;
     },
-    // 개발 중이면 주석 해제
+    // 개발 중엔 필요 시 주석 해제
     // retry: false,
     // refetchOnWindowFocus: false,
   });
@@ -62,7 +106,7 @@ export function useGithubListItems(data?: InfiniteData<GithubPostsPage>) {
   );
 }
 
-/** 🔗 repoLink 프리패치(변경 없음) */
+/** repoLink 프리패치 + 보강 + 중복 방지 + 클릭 핸들러 제공 */
 export function useGithubListWithLinks(data?: InfiniteData<GithubPostsPage>): {
   items: GithubListItem[];
   onRepoClick: (id: string) => Promise<void>;
@@ -79,6 +123,7 @@ export function useGithubListWithLinks(data?: InfiniteData<GithubPostsPage>): {
   }, []);
 
   useEffect(() => {
+    // TODO(perf): IntersectionObserver로 "화면에 들어온 카드"만 프리패치(성능 이슈 시)
     const targets = raw
       .filter(
         (it) =>
@@ -135,7 +180,7 @@ export function useGithubListWithLinks(data?: InfiniteData<GithubPostsPage>): {
         if (mountedRef.current) setLinkMap((prev) => ({ ...prev, [id]: link }));
         window.open(link, "_blank", "noopener,noreferrer");
       } catch {
-        // TODO[UX]: 토스트
+        // TODO(UX): 토스트 "레포 링크를 가져올 수 없습니다."
       }
     },
     [linkMap]

--- a/src/hooks/useGithubPosts.ts
+++ b/src/hooks/useGithubPosts.ts
@@ -1,73 +1,145 @@
 import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { GithubListItem } from "@components/Board/github/GithubList";
 import type { PostListItem } from "@api/posts";
+import { fetchGithubLinkById, fetchGithubListPage } from "@api/github";
 import { mapToGithubListItem } from "@src/features/posts/list/githubAdapter";
+import { LIST_SETTINGS } from "@src/constants/ui";
 
-const GITHUB_BOARD_ID = 5;
+const GITHUB_BOARD_SLUG = "github" as const; // 키에만 사용 (표시용)
+const PAGE_SIZE = LIST_SETTINGS.ITEMS_PER_PAGE;
 
-/** 응답/가드 타입 */
-type PostsListResponse = {
-  results: PostListItem[];
-  next?: string;
-  totalCount?: number;
-};
-type GithubPostsPage = { items: PostListItem[]; hasMore: boolean };
+type GithubPostsPage = { items: PostListItem[]; hasNext: boolean };
 
-type AnyObj = Record<string, unknown>;
-function isObj(v: unknown): v is AnyObj {
-  return typeof v === "object" && v !== null;
-}
-function isPostsListResponse(v: unknown): v is PostsListResponse {
-  return isObj(v) && Array.isArray(v.results);
-}
-
-/** 목록 호출 (page는 1-based) */
-async function fetchGithubPosts(page: number): Promise<GithubPostsPage> {
-  const url = new URL("/api/posts", window.location.origin);
-  url.searchParams.set("page", String(page));
-  url.searchParams.set("board_id", String(GITHUB_BOARD_ID));
-
-  const res = await fetch(url.toString(), {
-    credentials: "include", // TODO[AUTH]: 전역 규약으로 조정
-    headers: { "Content-Type": "application/json" },
+async function fetchGithubPage(page: number): Promise<GithubPostsPage> {
+  // 다음 페이지 존재 여부는 API 레이어가 판단
+  return fetchGithubListPage({
+    page,
+    page_size: PAGE_SIZE,
+    ordering: "-created_at",
   });
-
-  if (!res.ok) {
-    const msg = await res.text().catch(() => "");
-    throw new Error(msg || "GitHub 게시판 목록을 불러오지 못했습니다.");
-  }
-
-  const json: unknown = await res.json();
-  if (!isPostsListResponse(json)) {
-    // 스키마가 다르면 빈 페이지로 처리
-    return { items: [], hasMore: false };
-  }
-
-  const items = json.results;
-
-  const hasMore = items.length > 0;
-  return { items, hasMore };
 }
 
-export const GITHUB_POSTS_KEY = ["github-posts", GITHUB_BOARD_ID] as const;
+export const GITHUB_POSTS_KEY = [
+  "github-posts",
+  { board: GITHUB_BOARD_SLUG, pageSize: PAGE_SIZE, ordering: "-created_at" },
+] as const;
 
 export function useGithubPosts() {
   return useInfiniteQuery({
     queryKey: GITHUB_POSTS_KEY,
     initialPageParam: 1,
-    queryFn: ({ pageParam }) => fetchGithubPosts(pageParam as number),
-    getNextPageParam: (lastPage, _pages, lastParam) =>
-      lastPage.hasMore ? (lastParam as number) + 1 : undefined,
+    queryFn: ({ pageParam }) => fetchGithubPage(pageParam as number),
+    getNextPageParam: (lastPage, pages, lastParam) => {
+      // ✅ API 레이어가 알려준 hasNext만 신뢰
+      if (!lastPage.hasNext) return undefined;
+
+      // 안전 가드: 서버가 같은 페이지를 반복으로 주는 경우 차단
+      const prev = pages[pages.length - 2] as GithubPostsPage | undefined;
+      if (prev) {
+        const a = prev.items.map((p) => p.id);
+        const b = lastPage.items.map((p) => p.id);
+        if (a.length === b.length && a.every((v, i) => v === b[i])) {
+          return undefined;
+        }
+      }
+      return (lastParam as number) + 1;
+    },
+    // 개발 중이면 주석 해제
+    // retry: false,
+    // refetchOnWindowFocus: false,
   });
 }
 
-/** 페이지 → GithubList에 바로 넣을 items (어댑터 적용) */
-export function useGithubListItems(
-  data?: InfiniteData<GithubPostsPage>
-): GithubListItem[] {
-  return useMemo(() => {
-    const flat: PostListItem[] = data?.pages.flatMap((p) => p.items) ?? [];
-    return flat.map((it) => mapToGithubListItem(it));
-  }, [data]);
+export function useGithubListItems(data?: InfiniteData<GithubPostsPage>) {
+  const flat: PostListItem[] = useMemo(
+    () => data?.pages.flatMap((p) => p.items) ?? [],
+    [data]
+  );
+  return useMemo<GithubListItem[]>(
+    () => flat.map((it) => mapToGithubListItem(it)),
+    [flat]
+  );
+}
+
+/** 🔗 repoLink 프리패치(변경 없음) */
+export function useGithubListWithLinks(data?: InfiniteData<GithubPostsPage>): {
+  items: GithubListItem[];
+  onRepoClick: (id: string) => Promise<void>;
+} {
+  const raw = useGithubListItems(data);
+
+  const [linkMap, setLinkMap] = useState<Record<string, string>>({});
+  const mountedRef = useRef(true);
+  const busySetRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => void (mountedRef.current = false);
+  }, []);
+
+  useEffect(() => {
+    const targets = raw
+      .filter(
+        (it) =>
+          !it.repoLink && !linkMap[it.id] && !busySetRef.current.has(it.id)
+      )
+      .map((it) => it.id);
+
+    if (targets.length === 0) return;
+    targets.forEach((id) => busySetRef.current.add(id));
+
+    (async () => {
+      try {
+        const results = await Promise.all(
+          targets.map(async (id) => {
+            try {
+              const link = await fetchGithubLinkById(id);
+              return { id, link };
+            } catch {
+              return { id, link: "" as string };
+            }
+          })
+        );
+        if (!mountedRef.current) return;
+        setLinkMap((prev) => {
+          const next = { ...prev };
+          for (const { id, link } of results) if (link) next[id] = link;
+          return next;
+        });
+      } finally {
+        targets.forEach((id) => busySetRef.current.delete(id));
+      }
+    })();
+  }, [raw, linkMap]);
+
+  const items = useMemo(
+    () =>
+      raw.map((it) => ({
+        ...it,
+        repoLink: it.repoLink || linkMap[it.id] || "",
+      })),
+    [raw, linkMap]
+  );
+
+  const onRepoClick = useCallback(
+    async (id: string) => {
+      const cached = linkMap[id];
+      if (cached) {
+        window.open(cached, "_blank", "noopener,noreferrer");
+        return;
+      }
+      try {
+        const link = await fetchGithubLinkById(id);
+        if (!link) return;
+        if (mountedRef.current) setLinkMap((prev) => ({ ...prev, [id]: link }));
+        window.open(link, "_blank", "noopener,noreferrer");
+      } catch {
+        // TODO[UX]: 토스트
+      }
+    },
+    [linkMap]
+  );
+
+  return { items, onRepoClick };
 }

--- a/src/hooks/useGithubPosts.ts
+++ b/src/hooks/useGithubPosts.ts
@@ -1,0 +1,73 @@
+import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { GithubListItem } from "@components/Board/github/GithubList";
+import type { PostListItem } from "@api/posts";
+import { mapToGithubListItem } from "@src/features/posts/list/githubAdapter";
+
+const GITHUB_BOARD_ID = 5;
+
+/** 응답/가드 타입 */
+type PostsListResponse = {
+  results: PostListItem[];
+  next?: string;
+  totalCount?: number;
+};
+type GithubPostsPage = { items: PostListItem[]; hasMore: boolean };
+
+type AnyObj = Record<string, unknown>;
+function isObj(v: unknown): v is AnyObj {
+  return typeof v === "object" && v !== null;
+}
+function isPostsListResponse(v: unknown): v is PostsListResponse {
+  return isObj(v) && Array.isArray(v.results);
+}
+
+/** 목록 호출 (page는 1-based) */
+async function fetchGithubPosts(page: number): Promise<GithubPostsPage> {
+  const url = new URL("/api/posts", window.location.origin);
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("board_id", String(GITHUB_BOARD_ID));
+
+  const res = await fetch(url.toString(), {
+    credentials: "include", // TODO[AUTH]: 전역 규약으로 조정
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    throw new Error(msg || "GitHub 게시판 목록을 불러오지 못했습니다.");
+  }
+
+  const json: unknown = await res.json();
+  if (!isPostsListResponse(json)) {
+    // 스키마가 다르면 빈 페이지로 처리
+    return { items: [], hasMore: false };
+  }
+
+  const items = json.results;
+
+  const hasMore = items.length > 0;
+  return { items, hasMore };
+}
+
+export const GITHUB_POSTS_KEY = ["github-posts", GITHUB_BOARD_ID] as const;
+
+export function useGithubPosts() {
+  return useInfiniteQuery({
+    queryKey: GITHUB_POSTS_KEY,
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) => fetchGithubPosts(pageParam as number),
+    getNextPageParam: (lastPage, _pages, lastParam) =>
+      lastPage.hasMore ? (lastParam as number) + 1 : undefined,
+  });
+}
+
+/** 페이지 → GithubList에 바로 넣을 items (어댑터 적용) */
+export function useGithubListItems(
+  data?: InfiniteData<GithubPostsPage>
+): GithubListItem[] {
+  return useMemo(() => {
+    const flat: PostListItem[] = data?.pages.flatMap((p) => p.items) ?? [];
+    return flat.map((it) => mapToGithubListItem(it));
+  }, [data]);
+}

--- a/src/hooks/useSurveys.ts
+++ b/src/hooks/useSurveys.ts
@@ -6,9 +6,10 @@ import {
   type SurveyExtra,
 } from "@src/features/posts/list/adapters";
 import { fetchSurveyExtra } from "@src/api/posts.special";
+import { LIST_SETTINGS } from "@src/constants/ui";
 
 export const SURVEYS_KEY = ["surveys"] as const;
-const PAGE_SIZE = 20;
+const PAGE_SIZE = LIST_SETTINGS.ITEMS_PER_PAGE;
 
 type Page = { items: SurveyCardProps[]; hasMore: boolean; page: number };
 

--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -1,30 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import GithubList from "@components/Board/github/GithubList";
 import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
 import { formatYyyyMmDdHms } from "@utils/date";
 import { urlForPost } from "@src/utils/urlForPost";
-import { useGithubPosts, useGithubListItems } from "@hooks/useGithubPosts";
-
-/** 상세에서 링크만 가져오기 (타입가드 포함) */
-type GithubDetailResponse = { post_id?: number | string; link?: string };
-function isGithubDetailResponse(v: unknown): v is GithubDetailResponse {
-  return typeof v === "object" && v !== null;
-}
-async function fetchGithubLinkById(postId: string): Promise<string> {
-  const res = await fetch(`/api/posts/github/${postId}`, {
-    credentials: "include",
-    headers: { "Content-Type": "application/json" },
-  });
-  if (!res.ok) throw new Error("레포 링크 조회 실패");
-  const json: unknown = await res.json();
-  if (!isGithubDetailResponse(json) || typeof json.link !== "string") return "";
-  return json.link;
-}
+import { useGithubPosts, useGithubListWithLinks } from "@hooks/useGithubPosts";
 
 export default function GithubListPage() {
   const nav = useNavigate();
-
   const [lastLoadedAt, setLastLoadedAt] = useState(
     formatYyyyMmDdHms(new Date())
   );
@@ -40,67 +23,9 @@ export default function GithubListPage() {
     error,
     refetch,
   } = useGithubPosts();
-  const rawItems = useGithubListItems(data);
 
-  /** 링크 캐시/가드 */
-  const [repoLinkMap, setRepoLinkMap] = useState<Record<string, string>>({});
-  const mountedRef = useRef(true);
-  const busySetRef = useRef<Set<string>>(new Set());
+  const { items, onRepoClick } = useGithubListWithLinks(data);
 
-  useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  // 새로 추가된 아이템 중에서 repoLink 없는 것들만 상세로 보강
-  useEffect(() => {
-    const targets = rawItems
-      .filter(
-        (it) =>
-          !it.repoLink && !repoLinkMap[it.id] && !busySetRef.current.has(it.id)
-      )
-      .map((it) => it.id);
-
-    if (targets.length === 0) return;
-    targets.forEach((id) => busySetRef.current.add(id));
-
-    (async () => {
-      try {
-        const results = await Promise.all(
-          targets.map(async (id) => {
-            try {
-              const link = await fetchGithubLinkById(id);
-              return { id, link };
-            } catch {
-              return { id, link: "" };
-            }
-          })
-        );
-        if (!mountedRef.current) return;
-        setRepoLinkMap((prev) => {
-          const next = { ...prev };
-          for (const { id, link } of results) if (link) next[id] = link;
-          return next;
-        });
-      } finally {
-        targets.forEach((id) => busySetRef.current.delete(id));
-      }
-    })();
-  }, [rawItems, repoLinkMap]);
-
-  // 화면 전달용: repoLink 보강
-  const items = useMemo(
-    () =>
-      rawItems.map((it) => ({
-        ...it,
-        repoLink: it.repoLink || repoLinkMap[it.id] || "",
-      })),
-    [rawItems, repoLinkMap]
-  );
-
-  // 로딩/센티넬
   const isInitialLoading = items.length === 0 && !!isFetching;
   const listIsLoading = isInitialLoading || isFetchingNextPage;
 
@@ -128,38 +53,17 @@ export default function GithubListPage() {
     return "GitHub 게시판 목록을 불러오는 중 문제가 발생했습니다.";
   }, [isError, error]);
 
-  /** 레포 링크 클릭: 캐시 우선, 없으면 on-demand 조회 후 오픈 */
-  const handleRepoClick = useCallback(
-    async (id: string) => {
-      const cached = repoLinkMap[id];
-      if (cached) {
-        window.open(cached, "_blank", "noopener,noreferrer");
-        return;
-      }
-      try {
-        const link = await fetchGithubLinkById(id);
-        if (!link) return;
-        if (mountedRef.current)
-          setRepoLinkMap((prev) => ({ ...prev, [id]: link }));
-        window.open(link, "_blank", "noopener,noreferrer");
-      } catch {
-        // TODO[UX]: 토스트로 "레포 링크를 가져올 수 없습니다" 등 노출
-      }
-    },
-    [repoLinkMap]
-  );
-
   return (
     <div className="self-stretch w-[800px] max-w-full p-4">
       <section className="w-full rounded-xl border border-base-content/30 p-3 pb-8 h-[calc(100vh-200px)] overflow-hidden">
         <GithubList
           items={items}
           onItemClick={(id) => nav(urlForPost.postDetail("github", id))}
-          onRepoClick={handleRepoClick}
+          onRepoClick={onRepoClick}
           topBar={{
             boardName: "GitHub 게시판",
-            onOpenSort: () => {}, // TODO[SORT]: 훅 파라미터 연결
-            onOpenTag: () => {}, // TODO[TAGS]: 필터 파라미터 연결
+            onOpenSort: () => {}, // TODO[SORT]: ordering 훅 파라미터로 연결
+            onOpenTag: () => {}, // TODO[TAGS]: 훅/서버 필터 연결
             onWrite: () => nav(urlForPost.postCreate("github")),
           }}
           lastLoadedAt={lastLoadedAt}

--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -1,10 +1,15 @@
+// src/pages/GithubListPage.tsx
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import GithubList from "@components/Board/github/GithubList";
 import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
 import { formatYyyyMmDdHms } from "@utils/date";
 import { urlForPost } from "@src/utils/urlForPost";
-import { useGithubPosts, useGithubListWithLinks } from "@hooks/useGithubPosts";
+import {
+  useGithubPosts,
+  useGithubListWithLinks,
+  type SortValue,
+} from "@hooks/useGithubPosts";
 
 export default function GithubListPage() {
   const nav = useNavigate();
@@ -12,6 +17,18 @@ export default function GithubListPage() {
     formatYyyyMmDdHms(new Date())
   );
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
+
+  // ---------------------------
+  // TODO(sort): 정렬 상태를 UI와 연결 (SortRadioPopover → setSort)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [sort, setSort] = useState<SortValue>("latest");
+  // TODO(filter): 태그 필터 상태 — TagPopover/TagPicker와 연결
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [tagIds, setTagIds] = useState<number[] | undefined>(undefined);
+  // TODO(search): 검색어 상태 — SearchInput과 연결
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [search, setSearch] = useState<string | undefined>(undefined);
+  // ---------------------------
 
   const {
     data,
@@ -22,8 +39,15 @@ export default function GithubListPage() {
     isError,
     error,
     refetch,
-  } = useGithubPosts();
+  } = useGithubPosts({
+    // ⚠️ 지금은 동작 동일. 이후 UI 연결 시 아래 3개만 채워주면 끝
+    sort, // TODO(sort): SortRadioPopover onChange → setSort
+    tagIds, // TODO(tags): Tag UI onApply → setTagIds
+    search, // TODO(search): Search onSubmit → setSearch
+    // pageSize: 10,           // 필요 시 교체
+  });
 
+  // ✅ 링크/OG까지 보강된 items + onRepoClick
   const { items, onRepoClick } = useGithubListWithLinks(data);
 
   const isInitialLoading = items.length === 0 && !!isFetching;
@@ -62,8 +86,10 @@ export default function GithubListPage() {
           onRepoClick={onRepoClick}
           topBar={{
             boardName: "GitHub 게시판",
-            onOpenSort: () => {}, // TODO[SORT]: ordering 훅 파라미터로 연결
-            onOpenTag: () => {}, // TODO[TAGS]: 훅/서버 필터 연결
+            // TODO(sort): 팝오버 오픈 → 선택값 setSort → 훅 옵션 반영
+            onOpenSort: () => {},
+            // TODO(tags): 태그 팝오버 → 선택값 setTagIds → 훅 옵션 반영
+            onOpenTag: () => {},
             onWrite: () => nav(urlForPost.postCreate("github")),
           }}
           lastLoadedAt={lastLoadedAt}

--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import GithubList from "@components/Board/github/GithubList";
+import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
+import { formatYyyyMmDdHms } from "@utils/date";
+import { urlForPost } from "@src/utils/urlForPost";
+import { useGithubPosts, useGithubListItems } from "@hooks/useGithubPosts";
+
+/** 상세에서 링크만 가져오기 (타입가드 포함) */
+type GithubDetailResponse = { post_id?: number | string; link?: string };
+function isGithubDetailResponse(v: unknown): v is GithubDetailResponse {
+  return typeof v === "object" && v !== null;
+}
+async function fetchGithubLinkById(postId: string): Promise<string> {
+  const res = await fetch(`/api/posts/github/${postId}`, {
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) throw new Error("레포 링크 조회 실패");
+  const json: unknown = await res.json();
+  if (!isGithubDetailResponse(json) || typeof json.link !== "string") return "";
+  return json.link;
+}
+
+export default function GithubListPage() {
+  const nav = useNavigate();
+
+  const [lastLoadedAt, setLastLoadedAt] = useState(
+    formatYyyyMmDdHms(new Date())
+  );
+  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetching,
+    isError,
+    error,
+    refetch,
+  } = useGithubPosts();
+  const rawItems = useGithubListItems(data);
+
+  /** 링크 캐시/가드 */
+  const [repoLinkMap, setRepoLinkMap] = useState<Record<string, string>>({});
+  const mountedRef = useRef(true);
+  const busySetRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // 새로 추가된 아이템 중에서 repoLink 없는 것들만 상세로 보강
+  useEffect(() => {
+    const targets = rawItems
+      .filter(
+        (it) =>
+          !it.repoLink && !repoLinkMap[it.id] && !busySetRef.current.has(it.id)
+      )
+      .map((it) => it.id);
+
+    if (targets.length === 0) return;
+    targets.forEach((id) => busySetRef.current.add(id));
+
+    (async () => {
+      try {
+        const results = await Promise.all(
+          targets.map(async (id) => {
+            try {
+              const link = await fetchGithubLinkById(id);
+              return { id, link };
+            } catch {
+              return { id, link: "" };
+            }
+          })
+        );
+        if (!mountedRef.current) return;
+        setRepoLinkMap((prev) => {
+          const next = { ...prev };
+          for (const { id, link } of results) if (link) next[id] = link;
+          return next;
+        });
+      } finally {
+        targets.forEach((id) => busySetRef.current.delete(id));
+      }
+    })();
+  }, [rawItems, repoLinkMap]);
+
+  // 화면 전달용: repoLink 보강
+  const items = useMemo(
+    () =>
+      rawItems.map((it) => ({
+        ...it,
+        repoLink: it.repoLink || repoLinkMap[it.id] || "",
+      })),
+    [rawItems, repoLinkMap]
+  );
+
+  // 로딩/센티넬
+  const isInitialLoading = items.length === 0 && !!isFetching;
+  const listIsLoading = isInitialLoading || isFetchingNextPage;
+
+  const { sentinelRef } = useInfiniteScroll({
+    root: rootEl,
+    rootMargin: "400px 0px",
+    threshold: 0,
+    disabled: listIsLoading || !hasNextPage || isError,
+    onIntersect: async () => {
+      await fetchNextPage();
+      setLastLoadedAt(formatYyyyMmDdHms(new Date()));
+    },
+  });
+
+  const handleRefresh = useCallback(() => {
+    setLastLoadedAt(formatYyyyMmDdHms(new Date()));
+    refetch();
+  }, [refetch]);
+
+  const errorText = useMemo(() => {
+    if (!isError) return undefined;
+    if (error && typeof error === "object" && "message" in error) {
+      return (error as { message?: string }).message;
+    }
+    return "GitHub 게시판 목록을 불러오는 중 문제가 발생했습니다.";
+  }, [isError, error]);
+
+  /** 레포 링크 클릭: 캐시 우선, 없으면 on-demand 조회 후 오픈 */
+  const handleRepoClick = useCallback(
+    async (id: string) => {
+      const cached = repoLinkMap[id];
+      if (cached) {
+        window.open(cached, "_blank", "noopener,noreferrer");
+        return;
+      }
+      try {
+        const link = await fetchGithubLinkById(id);
+        if (!link) return;
+        if (mountedRef.current)
+          setRepoLinkMap((prev) => ({ ...prev, [id]: link }));
+        window.open(link, "_blank", "noopener,noreferrer");
+      } catch {
+        // TODO[UX]: 토스트로 "레포 링크를 가져올 수 없습니다" 등 노출
+      }
+    },
+    [repoLinkMap]
+  );
+
+  return (
+    <div className="self-stretch w-[800px] max-w-full p-4">
+      <section className="w-full rounded-xl border border-base-content/30 p-3 pb-8 h-[calc(100vh-200px)] overflow-hidden">
+        <GithubList
+          items={items}
+          onItemClick={(id) => nav(urlForPost.postDetail("github", id))}
+          onRepoClick={handleRepoClick}
+          topBar={{
+            boardName: "GitHub 게시판",
+            onOpenSort: () => {}, // TODO[SORT]: 훅 파라미터 연결
+            onOpenTag: () => {}, // TODO[TAGS]: 필터 파라미터 연결
+            onWrite: () => nav(urlForPost.postCreate("github")),
+          }}
+          lastLoadedAt={lastLoadedAt}
+          onRefresh={handleRefresh}
+          isLoading={listIsLoading}
+          isError={isError}
+          errorText={errorText}
+          hasMore={!!hasNextPage}
+          sentinelRef={sentinelRef}
+          scrollRootRef={setRootEl}
+          emptyText="등록된 GitHub 게시글이 없습니다."
+          className="py-2"
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -18,15 +18,19 @@ export default function GithubListPage() {
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
 
   // ---------------------------
+  /*
   // TODO(sort): 정렬 상태를 UI와 연결 (SortRadioPopover → setSort)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [sort, setSort] = useState<SortValue>("latest");
   // TODO(filter): 태그 필터 상태 — TagPopover/TagPicker와 연결
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [tagIds, setTagIds] = useState<number[] | undefined>(undefined);
   // TODO(search): 검색어 상태 — SearchInput과 연결
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [search, setSearch] = useState<string | undefined>(undefined);
+  */
+
+  // TODO: 현재 세터 미사용으로 인해 배포 오류 나는 것으로 예상, 임시로 아래와 같이 코드 사용
+  const [sort] = useState<SortValue>("latest");
+  const [tagIds] = useState<number[] | undefined>(undefined);
+  const [search] = useState<string | undefined>(undefined);
   // ---------------------------
 
   const {

--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -1,4 +1,3 @@
-// src/pages/GithubListPage.tsx
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import GithubList from "@components/Board/github/GithubList";

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -53,6 +53,7 @@ import SurveyListPage from "@src/pages/boards/SurveyListPage";
 import TestGithubList from "@src/pages/test/BoardList/TestGithubList";
 import MainLayout from "@src/layouts/MainLayout";
 import WritePostPage from "@src/components/Board/WritePostPage";
+import GithubListPage from "@src/pages/boards/GithubListPage";
 
 /** 공개(보호 불필요) 경로 목록 */
 const PUBLIC_PATHS: ReadonlySet<string> = new Set([
@@ -255,10 +256,7 @@ export default function AppRouter() {
         <Route path="/boards/jobs" element={<PostListPage board="jobs" />} />
         <Route path="/boards/info" element={<PostListPage board="info" />} />
         <Route path="/boards/survey" element={<SurveyListPage />} />
-        <Route
-          path="/boards/github"
-          element={<PostListPage board="github" />}
-        />
+        <Route path="/boards/github" element={<GithubListPage />} />
 
         {/* 인증 로비(공개) */}
         <Route path={PATHS.AUTH} element={<LandingPage />} />
@@ -294,7 +292,7 @@ export default function AppRouter() {
           />
           <Route path={PATHS.SURVEY_BOARD} element={<SurveyListPage />} />
 
-          <Route path={PATHS.GITHUB_BOARD} element={<TestGithubList />} />
+          <Route path={PATHS.GITHUB_BOARD} element={<GithubListPage />} />
           <Route path={PATHS.POST_CREATE} element={<WritePostPage />} />
           <Route path={PATHS.POST_DETAIL} element={<PostDetailPage />} />
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
   // server: {
   //   proxy: {
   //     "/api": {
-  //       target: "https://www.ozboard.shop/",
+  //       // target: "https://www.ozboard.shop/",
+  //       target: "http://localhost:8000/", // 로컬 도커 테스트용
   //       changeOrigin: true,
   //       secure: false,
   //       // ★ 백엔드가 프로젝트 urls.py에서 path('api/', ...)로 걸려있다면 rewrite 필요 없음


### PR DESCRIPTION
- 깃허브 API 연결, repoLink는 `/api/posts/github/${postId}` 쪽에서 받아옴 (@api/github.ts)
- og 썸네일도 repoLink 통해 제작
- 깃허브 게시판 목록용 훅과 페이지 제작
- 앱 라우트 연결

특이사항: 자유, 취업, 정보 게시판 반응형 카드로 보이는 것 UI 통일감 위해 삭제(주석 처리)

<img width="1908" height="926" alt="image" src="https://github.com/user-attachments/assets/055a5afe-cb37-4d21-bfeb-cf1441e9e0a1" />

---

closes #119 