### PR TITLE
[feat] 태그 API 구현

### DIFF
--- a/docs/How-to-use-TagBadge.md
+++ b/docs/How-to-use-TagBadge.md
@@ -1,4 +1,4 @@
-# TagBadge 호출법
+# TagBadge 호출법 (목 버전)
 
 작성자: 이명우
 
@@ -29,3 +29,61 @@ const { tags, loading, error } = useAssignedTags();
 import { profileToTagsMock } from "@mocks/tags.mock";
 const tags = profileToTagsMock("11기", "프론트");
 ```
+
+---
+
+# TagBadge 호출법 (서버 & 목 통합 훅 버전)
+
+작성자: 함서연 (2025.08.23)
+
+## 📌 개요
+
+기존 명우 님의 `useAssignedTags` 기능을 최대한 유지하면서,
+현재 로그인 사용자 또는 게시글 작성자의 태그(기수/포지션)을 불러와 배지로 표시할 수 있도록 하였습니다.
+
+실서버에서는 오즈키(`GET /api/user/tag`, `GET /api/posts/:id/`)를 우선 사용하고, 목/구버전 환경에서는 프로필(`GET /api/user/profile`)로 자동 폴백됩니다.
+
+## 🛠 사용 방법
+
+### 1) 현재 로그인 사용자 태그
+
+```ts
+import { useAssignedTags } from "@hooks/useAssignedTags";
+import AssignedTagList from "@components/tags/AssignedTagList";
+
+const { tags, loading, error, valid } = useAssignedTags("me");
+
+return <AssignedTagList tags={tags} />;
+```
+
+### 2) 게시글 작성자 태그 (응답에 user가 이미 있을 때)
+
+```ts
+import { useAssignedTags } from "@hooks/useAssignedTags";
+import AssignedTagList from "@components/tags/AssignedTagList";
+
+// post.user: { id, tag_class: "FE"|"BE", tag_number: number }
+const { tags, loading, error, valid } = useAssignedTags("author", {
+  inlineUser: post.user,
+});
+
+return <AssignedTagList tags={tags} />;
+```
+
+### 3) 게시글 작성자 태그 (user가 없어서 상세 호출이 필요할 때)
+
+```ts
+import { useAssignedTags } from "@hooks/useAssignedTags";
+import AssignedTagList from "@components/tags/AssignedTagList";
+
+const { tags, loading, error, valid } = useAssignedTags("author", {
+  postId: post.id, // 내부에서 /api/posts/:id/ 1회 호출
+});
+
+return <AssignedTagList tags={tags} />;
+```
+
+## 참고사항
+
+- `valid`: “기수 1개 + 포지션 1개”가 모두 존재하면 `true`. 아니면 `false`이며 `error`에 이유가 담깁니다.
+- 목/개발 환경에서도 동일 코드로 동작합니다(프로필 폴백 자동).

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -1,3 +1,5 @@
+// =========================== API 이전 버전 (명우) ===========================
+
 // 회원 프로필 기반으로 "기수 1개 + 포지션 1개" 자동 지정 태그를 조회하는 API 모듈.
 // 참고: @api/client (axios 인스턴스/401 재시도), auth.ts 의 pickFirst/ENDPOINTS 사용 패턴과 동일.
 
@@ -108,6 +110,59 @@ export async function getMyAssignedTags(): Promise<Tag[]> {
     // auth.ts 스타일: unknown → Error 내로우잉
     const message =
       e instanceof Error ? e.message : "Failed to load assigned tags";
+    throw new Error(message);
+  }
+}
+
+// =========================== API 연결 버전 (서연) ===========================
+
+// 오즈키 응답 → Tag[] 변환 어댑터
+import { adaptUserTag } from "@src/features/tags/adapters";
+
+// 서버의 user 태그 응답 형태
+export interface RawUserTag {
+  id: number; // oz_key.id
+  tag_class: "FE" | "BE"; // 포지션 코드
+  tag_number: number; // 기수 (예: 11)
+}
+
+/**
+ * 현재 로그인 사용자 태그
+ * - 성공: cohort("11기") + position("프론트/백엔드") 2개 반환
+ * - 401: 빈 배열 반환(미노출)
+ */
+export async function getMyAssignedTagsFromOzKey(): Promise<Tag[]> {
+  try {
+    const { data, status } = await api.get<RawUserTag | null>(
+      ENDPOINTS.USER_TAG,
+      { withCredentials: true }
+    );
+    if (status === 401 || !data) return [];
+    return adaptUserTag(data);
+  } catch (e: unknown) {
+    const message =
+      e instanceof Error ? e.message : "Failed to load oz-key assigned tags";
+    throw new Error(message);
+  }
+}
+
+/**
+ * 게시글 작성자 태그
+ * - GET /api/posts/:id/ (주의: 끝에 슬래시 포함. 예: /api/posts/4/)
+ * - 응답 내 data.user 가 RawUserTag
+ */
+export async function getPostAuthorAssignedTags(
+  postId: string | number
+): Promise<Tag[]> {
+  try {
+    const url = `${ENDPOINTS.POST_DETAIL}/${postId}/`;
+    const { data } = await api.get<{ user?: RawUserTag | null }>(url, {
+      withCredentials: true,
+    });
+    return adaptUserTag(data?.user ?? null);
+  } catch (e: unknown) {
+    const message =
+      e instanceof Error ? e.message : "Failed to load post author tags";
     throw new Error(message);
   }
 }

--- a/src/api/tags.ts
+++ b/src/api/tags.ts
@@ -1,44 +1,41 @@
-// =========================== API 이전 버전 (명우) ===========================
-
-// 회원 프로필 기반으로 "기수 1개 + 포지션 1개" 자동 지정 태그를 조회하는 API 모듈.
-// 참고: @api/client (axios 인스턴스/401 재시도), auth.ts 의 pickFirst/ENDPOINTS 사용 패턴과 동일.
-
 import { api } from "@api/client";
 import { ENDPOINTS } from "@constants/endpoints";
 import type { Tag } from "@src/types/tag";
 import { pickFirst } from "@src/utils/pickFirst";
+import { adaptUserTag } from "@src/features/tags/adapters";
 
-/** 서버가 다양한 스키마로 줄 수 있으니, 최대한 유연하게 받기 위한 타입 (any 금지) */
+/** 서버의 오즈키 기반 태그 구조 (ex. /api/user/tag, /api/posts/:id user) */
+export interface RawUserTag {
+  id: number; // oz_key.id
+  tag_class: "FE" | "BE"; // 포지션
+  tag_number: number; // 기수 (예: 11)
+}
+
+/** 프로필 기반(구버전/목) 구조: 다양한 키들 중에서 기수/포지션 추출 */
 interface RawUserProfile {
-  // 공통
   id?: string | number;
   email?: string;
-
-  // 최상위 혹은 user 객체 안에 있을 수 있는 프로필 필드들
   user?: {
     cohort?: string | number;
     generation?: string | number;
     class?: string | number;
     term?: string | number;
-
     position?: string;
     role?: string;
     track?: string;
     job?: string;
   };
-
   cohort?: string | number;
   generation?: string | number;
   class?: string | number;
   term?: string | number;
-
   position?: string;
   role?: string;
   track?: string;
   job?: string;
 }
 
-/** "11기" 처럼 표시용 문자열로 정규화 */
+/** 프로필 → "11기" 정규화 */
 function normalizeCohort(raw: RawUserProfile): string | null {
   const value = pickFirst(
     raw?.cohort,
@@ -50,16 +47,13 @@ function normalizeCohort(raw: RawUserProfile): string | null {
     raw?.user?.class,
     raw?.user?.term
   );
-
   if (value == null) return null;
-
-  // 숫자 11 -> "11기", "11기" -> 그대로
   if (typeof value === "number") return `${value}기`;
   const s = String(value).trim();
-  // 이미 "기"가 붙어있으면 통과, 아니면 붙여줌
   return /기$/.test(s) ? s : `${s}기`;
 }
 
+/** 프로필 → 포지션 문자열 정규화 */
 function normalizePosition(raw: RawUserProfile): string | null {
   const value = pickFirst(
     raw?.position,
@@ -71,98 +65,88 @@ function normalizePosition(raw: RawUserProfile): string | null {
     raw?.user?.track,
     raw?.user?.job
   );
-  if (value == null) return null;
-  return String(value).trim();
+  return value == null ? null : String(value).trim();
 }
 
-const COHORT_ID = (cohort: string) => `cohort-${cohort.replace(/기$/, "")}`;
-const POSITION_ID = (position: string) => `position-${position}`;
-
-/** 서버 응답 → Tag[] (cohort 1 + position 1) */
-export function normalizeUserToAssignedTags(raw: RawUserProfile): Tag[] {
+/** 프로필 응답 → Tag[] */
+function normalizeUserToAssignedTags(raw: RawUserProfile): Tag[] {
   const cohort = normalizeCohort(raw);
   const position = normalizePosition(raw);
-
   const tags: Tag[] = [];
-  if (cohort) {
+  if (cohort)
     tags.push({
-      id: COHORT_ID(cohort),
+      id: `cohort-${cohort.replace(/기$/, "")}`,
       label: cohort,
       category: "cohort",
     });
-  }
-  if (position) {
+  if (position)
     tags.push({
-      id: POSITION_ID(position),
+      id: `position-${position}`,
       label: position,
       category: "position",
     });
-  }
   return tags;
 }
 
-/** 내 프로필(/me)에서 태그 2개를 가져옴 */
+/** 유틸: Tag[]가 “cohort 1 + position 1”인지 검사 */
+export function isValidAssigned(tags: Tag[]): boolean {
+  const c = tags.filter((t) => t.category === "cohort").length === 1;
+  const p = tags.filter((t) => t.category === "position").length === 1;
+  return c && p;
+}
+
+/** [ME] 현재 로그인 사용자 태그 (오즈키 우선 → 프로필 폴백). 목에서도 동작. */
 export async function getMyAssignedTags(): Promise<Tag[]> {
+  // 1) v2 오즈키 우선
   try {
-    const { data } = await api.get<RawUserProfile>(ENDPOINTS.USER_PROFILE);
+    const { data, status } = await api.get<RawUserTag | null>(
+      ENDPOINTS.USER_TAG,
+      {
+        withCredentials: true,
+      }
+    );
+    if (status !== 401 && data) {
+      const v2 = adaptUserTag(data);
+      if (v2.length > 0) return v2;
+    }
+  } catch {
+    // 무해하게 폴백
+  }
+
+  // 2) v1 프로필 폴백 (목/구버전)
+  try {
+    const { data } = await api.get<RawUserProfile>(ENDPOINTS.USER_PROFILE, {
+      withCredentials: true,
+    });
     return normalizeUserToAssignedTags(data);
   } catch (e: unknown) {
-    // auth.ts 스타일: unknown → Error 내로우잉
     const message =
       e instanceof Error ? e.message : "Failed to load assigned tags";
     throw new Error(message);
   }
 }
 
-// =========================== API 연결 버전 (서연) ===========================
-
-// 오즈키 응답 → Tag[] 변환 어댑터
-import { adaptUserTag } from "@src/features/tags/adapters";
-
-// 서버의 user 태그 응답 형태
-export interface RawUserTag {
-  id: number; // oz_key.id
-  tag_class: "FE" | "BE"; // 포지션 코드
-  tag_number: number; // 기수 (예: 11)
-}
-
 /**
- * 현재 로그인 사용자 태그
- * - 성공: cohort("11기") + position("프론트/백엔드") 2개 반환
- * - 401: 빈 배열 반환(미노출)
+ * [AUTHOR] 게시글 작성자 태그
+ * - 우선: post.user(오즈키 구조)가 있다면 즉시 변환
+ * - 없으면: /api/posts/:id/ 호출하여 data.user에서 변환
+ * - 목에서도: /api/posts/:id/가 없다면 post 인라인 값으로만 처리
  */
-export async function getMyAssignedTagsFromOzKey(): Promise<Tag[]> {
-  try {
-    const { data, status } = await api.get<RawUserTag | null>(
-      ENDPOINTS.USER_TAG,
-      { withCredentials: true }
-    );
-    if (status === 401 || !data) return [];
-    return adaptUserTag(data);
-  } catch (e: unknown) {
-    const message =
-      e instanceof Error ? e.message : "Failed to load oz-key assigned tags";
-    throw new Error(message);
+export async function getAuthorAssignedTags(opts: {
+  postId?: string | number;
+  inlineUser?: RawUserTag | null;
+}): Promise<Tag[]> {
+  // 1) 인라인 user(오즈키 구조) 우선
+  if (opts.inlineUser) {
+    const inline = adaptUserTag(opts.inlineUser);
+    if (inline.length > 0) return inline;
   }
-}
 
-/**
- * 게시글 작성자 태그
- * - GET /api/posts/:id/ (주의: 끝에 슬래시 포함. 예: /api/posts/4/)
- * - 응답 내 data.user 가 RawUserTag
- */
-export async function getPostAuthorAssignedTags(
-  postId: string | number
-): Promise<Tag[]> {
-  try {
-    const url = `${ENDPOINTS.POST_DETAIL}/${postId}/`;
-    const { data } = await api.get<{ user?: RawUserTag | null }>(url, {
-      withCredentials: true,
-    });
-    return adaptUserTag(data?.user ?? null);
-  } catch (e: unknown) {
-    const message =
-      e instanceof Error ? e.message : "Failed to load post author tags";
-    throw new Error(message);
-  }
+  // 2) 필요 시 상세 호출
+  if (opts.postId == null) return [];
+  const url = `${ENDPOINTS.POST_DETAIL}/${opts.postId}/`;
+  const { data } = await api.get<{ user?: RawUserTag | null }>(url, {
+    withCredentials: true,
+  });
+  return adaptUserTag(data?.user ?? null);
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -5,4 +5,6 @@ export const ENDPOINTS = {
   TOKEN_REVOKE: "/api/auth/token/revoke",
   KEY_VERIFY: "/api/auth/key-verify",
   USER_PROFILE: "/api/user/profile",
+  USER_TAG: "/api/user/tag",
+  POST_DETAIL: "/api/posts", // (뒤에 /:id/ 붙여서 사용)
 } as const;

--- a/src/features/tags/adapters.ts
+++ b/src/features/tags/adapters.ts
@@ -1,0 +1,29 @@
+import type { RawUserTag, Tag } from "@src/types/tag";
+
+/** 서버의 1개 user 태그 객체 → 프론트용 Tag[] (cohort/position 2개로 분리) */
+export function adaptUserTag(raw?: RawUserTag | null): Tag[] {
+  if (!raw) return [];
+
+  const tags: Tag[] = [];
+
+  // cohort (기수)
+  if (raw.tag_number != null) {
+    tags.push({
+      id: `${raw.id}-cohort`,
+      category: "cohort",
+      label: `${raw.tag_number}기`,
+    });
+  }
+
+  // position (FE/BE)
+  if (raw.tag_class) {
+    const label = raw.tag_class === "FE" ? "프론트" : "백엔드";
+    tags.push({
+      id: `${raw.id}-pos`,
+      category: "position",
+      label,
+    });
+  }
+
+  return tags;
+}

--- a/src/hooks/useAssignedTags.ts
+++ b/src/hooks/useAssignedTags.ts
@@ -1,14 +1,27 @@
 import { useEffect, useState } from "react";
-import { getMyAssignedTags } from "@api/tags";
 import type { Tag } from "@src/types/tag";
+import {
+  getMyAssignedTags,
+  getAuthorAssignedTags,
+  isValidAssigned,
+} from "@api/tags";
+import type { RawUserTag } from "@api/tags";
 
-function isValid(tags: Tag[]): boolean {
-  const cohort = tags.filter((t) => t.category === "cohort").length === 1;
-  const position = tags.filter((t) => t.category === "position").length === 1;
-  return cohort && position;
-}
-
-export function useAssignedTags() {
+/**
+ * target:
+ *  - "me"     : 현재 로그인 사용자의 태그
+ *  - "author" : 게시글 작성자의 태그
+ *
+ * author 옵션:
+ *  - postId     : 상세 호출이 필요한 경우 사용
+ *  - inlineUser : 응답에 이미 user { id, tag_class, tag_number }가 들어온 경우 전달
+ *
+ * 반환 형태는 기존 훅과 동일한 필드 포함: { tags, loading, error, valid }
+ */
+export function useAssignedTags(
+  target: "me" | "author" = "me",
+  author?: { postId?: string | number; inlineUser?: RawUserTag | null }
+) {
   const [tags, setTags] = useState<Tag[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -16,28 +29,47 @@ export function useAssignedTags() {
 
   useEffect(() => {
     let cancelled = false;
+
     (async () => {
       setLoading(true);
       setError(null);
       try {
-        const result = await getMyAssignedTags();
+        let result: Tag[] = [];
+        if (target === "me") {
+          result = await getMyAssignedTags();
+        } else {
+          result = await getAuthorAssignedTags({
+            postId: author?.postId,
+            inlineUser: author?.inlineUser ?? null,
+          });
+        }
         if (cancelled) return;
         setTags(result);
-        setValid(isValid(result));
-        if (!isValid(result)) setError("기수 1개 + 포지션 1개가 필요합니다.");
+        const ok = isValidAssigned(result);
+        setValid(ok);
+        if (!ok) setError("기수 1개 + 포지션 1개가 필요합니다.");
       } catch (e: unknown) {
-        if (!cancelled)
+        if (!cancelled) {
           setError(
             e instanceof Error ? e.message : "태그를 불러오지 못했습니다."
           );
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
     })();
+
     return () => {
       cancelled = true;
     };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    target,
+    author?.postId,
+    author?.inlineUser?.id,
+    author?.inlineUser?.tag_class,
+    author?.inlineUser?.tag_number,
+  ]);
 
   return { tags, loading, error, valid };
 }

--- a/src/hooks/useGithubPosts.ts
+++ b/src/hooks/useGithubPosts.ts
@@ -1,9 +1,13 @@
+import React from "react";
 import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { GithubListItem } from "@components/Board/github/GithubList";
 import type { PostListItem } from "@api/posts";
 import { fetchGithubLinkById, fetchGithubListPage } from "@api/github";
 import { mapToGithubListItem } from "@src/features/posts/list/githubAdapter";
+import AssignedTagList from "@components/tags/AssignedTagList";
+import { adaptUserTag } from "@src/features/tags/adapters";
+import type { RawUserTag } from "@src/types/tag";
 
 // NOTE: 키 표시에만 사용 (API 파라미터는 github.ts에서 board id 사용)
 const GITHUB_BOARD_SLUG = "github" as const;
@@ -47,7 +51,6 @@ async function fetchGithubPage(
   page: number,
   opt?: UseGithubPostsOptions
 ): Promise<GithubPostsPage> {
-  // API 레이어가 hasNext를 판단 (next 존재 유무)
   return fetchGithubListPage({
     page,
     page_size: opt?.pageSize ?? DEFAULT_PAGE_SIZE,
@@ -63,7 +66,7 @@ export function useGithubPosts(opt?: UseGithubPostsOptions) {
   const ordering = toOrdering(opt?.sort) ?? "-created_at";
 
   return useInfiniteQuery({
-    // ⚠️ 키에 옵션 포함 (정렬/필터 변경 시 캐시 분리)
+    // 키에 옵션 포함 (정렬/필터 변경 시 캐시 분리)
     queryKey: [
       "github-posts",
       {
@@ -79,7 +82,6 @@ export function useGithubPosts(opt?: UseGithubPostsOptions) {
     getNextPageParam: (lastPage, pages, lastParam) => {
       if (!lastPage.hasNext) return undefined;
 
-      // 안전 가드: 같은 페이지 반복 방지
       const prev = pages[pages.length - 2] as GithubPostsPage | undefined;
       if (prev) {
         const a = prev.items.map((p) => p.id);
@@ -95,13 +97,43 @@ export function useGithubPosts(opt?: UseGithubPostsOptions) {
   });
 }
 
+/**
+ * 리스트 아이템 변환 단계에서 tagSlot을 주입
+ * - PostListItem에 user(오즈키 태그 원본)가 포함되어 있다면 AssignedTagList를 생성해 tagSlot에 넣음
+ * - 포함되지 않았다면 tagSlot은 생략(상세에서만 태그 노출)
+ */
 export function useGithubListItems(data?: InfiniteData<GithubPostsPage>) {
   const flat: PostListItem[] = useMemo(
     () => data?.pages.flatMap((p) => p.items) ?? [],
     [data]
   );
+
+  type WithUser =
+    | {
+        user?: {
+          id: number;
+          tag_class: "FE" | "BE";
+          tag_number: number;
+        } | null;
+      }
+    | Record<string, unknown>;
+
   return useMemo<GithubListItem[]>(
-    () => flat.map((it) => mapToGithubListItem(it)),
+    () =>
+      flat.map((it) => {
+        const base = mapToGithubListItem(it);
+        const rawUser = (it as WithUser).user as RawUserTag | null | undefined;
+        const tags = adaptUserTag(rawUser);
+        const tagSlot =
+          tags.length > 0
+            ? React.createElement(AssignedTagList, { tags })
+            : undefined;
+
+        return {
+          ...base,
+          tagSlot,
+        };
+      }),
     [flat]
   );
 }

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,8 +1,14 @@
 export type TagCategory = "cohort" | "position";
 
 export type Tag = {
-  id: string;
-  label: string;
-  category: TagCategory; // cohort or position
-  color?: string;
+  id: string; // ex) "2-cohort", "2-pos"
+  category: TagCategory; // "cohort" | "position"
+  label: string; // "11기" | "프론트" | "백엔드"
+};
+
+/** 서버 응답의 user 태그 구조 (예: /api/posts/:id user) */
+export type RawUserTag = {
+  id: number; // oz_key.id
+  tag_class: "FE" | "BE";
+  tag_number: number; // 기수 (예: 11)
 };


### PR DESCRIPTION
태그 API 연동.
로그인 사용자 태그와 게시글 작성자 태그를 불러와서 useAssignedTags → AssignedTagList → TagBadge로 표시.
전 범위에서 공통 적용.

테스트 목적으로 깃허브 게시글 목록에 추가해봤는데, 잘 작동합니다.
<img width="923" height="781" alt="image" src="https://github.com/user-attachments/assets/8704de1c-24da-4ef6-ba26-6c8d60ee93ed" />


사용 방법 docs에 추가해뒀습니다.

# TagBadge 호출법 (서버 & 목 통합 훅 버전)

작성자: 함서연 (2025.08.23)

## 📌 개요

기존 명우 님의 `useAssignedTags` 기능을 최대한 유지하면서,
현재 로그인 사용자 또는 게시글 작성자의 태그(기수/포지션)을 불러와 배지로 표시할 수 있도록 하였습니다.

실서버에서는 오즈키(`GET /api/user/tag`, `GET /api/posts/:id/`)를 우선 사용하고, 목/구버전 환경에서는 프로필(`GET /api/user/profile`)로 자동 폴백됩니다.

## 🛠 사용 방법

### 1) 현재 로그인 사용자 태그

```ts
import { useAssignedTags } from "@hooks/useAssignedTags";
import AssignedTagList from "@components/tags/AssignedTagList";

const { tags, loading, error, valid } = useAssignedTags("me");

return <AssignedTagList tags={tags} />;
```

### 2) 게시글 작성자 태그 (응답에 user가 이미 있을 때)

```ts
import { useAssignedTags } from "@hooks/useAssignedTags";
import AssignedTagList from "@components/tags/AssignedTagList";

// post.user: { id, tag_class: "FE"|"BE", tag_number: number }
const { tags, loading, error, valid } = useAssignedTags("author", {
  inlineUser: post.user,
});

return <AssignedTagList tags={tags} />;
```

### 3) 게시글 작성자 태그 (user가 없어서 상세 호출이 필요할 때)

```ts
import { useAssignedTags } from "@hooks/useAssignedTags";
import AssignedTagList from "@components/tags/AssignedTagList";

const { tags, loading, error, valid } = useAssignedTags("author", {
  postId: post.id, // 내부에서 /api/posts/:id/ 1회 호출
});

return <AssignedTagList tags={tags} />;
```

## 참고사항

- `valid`: “기수 1개 + 포지션 1개”가 모두 존재하면 `true`. 아니면 `false`이며 `error`에 이유가 담깁니다.
- 목/개발 환경에서도 동일 코드로 동작합니다(프로필 폴백 자동).


---

closes #146 