### PR TITLE
[fix] 게시판 목록 무한 스크롤 404 에러 이슈 해결

### DIFF
--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -66,8 +66,14 @@ export async function fetchPosts(params?: {
     return Array.isArray(data) ? data : (data?.results ?? []);
   } catch (e: unknown) {
     const err = e as AxiosError;
-    if (err.response?.status === 404) return [];
-    throw e;
+    if (err.response?.status === 404) {
+      if (import.meta.env.DEV) {
+        console.info("[useInfiniteQuery] 더 불러올 데이터 없음 (404 수신)");
+      }
+      return [];
+    }
+    // 404가 아니면 그대로 throw
+    throw err;
   }
 }
 

--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -2,6 +2,7 @@
 import api from "@api/client";
 import { BOARD_ID, type BoardSlug } from "@constants/boards";
 import { getBoardIdBySlug } from "./boardMap";
+import type { AxiosError } from "axios";
 
 /** ----- 타입 ----- */
 export type PostListItem = {
@@ -47,7 +48,7 @@ export async function fetchPosts(params?: {
   board?: BoardSlug; // 슬러그로 받되 내부에서 id로 변환
   search?: string;
   ordering?: "-created_at" | "created_at" | "-view_count" | "view_count";
-  page?: number;
+  page?: number; // DRF는 1-base, 0은 절대 보내지 않기
   page_size?: number;
 }) {
   const query = new URLSearchParams();
@@ -58,12 +59,16 @@ export async function fetchPosts(params?: {
   if (params?.page) query.set("page", String(params.page));
   if (params?.page_size) query.set("page_size", String(params.page_size));
 
-  // 프록시 제거: /api 접두어 필수
-  const { data } = await api.get<{ results?: PostListItem[] } | PostListItem[]>(
-    `/api/posts/?${query.toString()}`
-  );
-
-  return Array.isArray(data) ? data : (data?.results ?? []);
+  try {
+    const { data } = await api.get<
+      { results?: PostListItem[]; next?: string } | PostListItem[]
+    >(`/api/posts/?${query.toString()}`);
+    return Array.isArray(data) ? data : (data?.results ?? []);
+  } catch (e: unknown) {
+    const err = e as AxiosError;
+    if (err.response?.status === 404) return [];
+    throw e;
+  }
 }
 
 export async function fetchPostDetail(id: number) {

--- a/src/hooks/useBoardPosts.ts
+++ b/src/hooks/useBoardPosts.ts
@@ -5,6 +5,7 @@ import { fetchPosts, type PostListItem } from "@api/posts";
 import type { BoardSlug } from "@src/constants/boards";
 import { LIST_SETTINGS } from "@src/constants/ui";
 import type { SortValue } from "@src/types/sort";
+import type { AxiosError } from "axios";
 
 type FetchParams = NonNullable<Parameters<typeof fetchPosts>[0]>;
 type Ordering = NonNullable<FetchParams["ordering"]>;
@@ -24,19 +25,18 @@ export function useBoardPosts(
     /** UI 정렬값(예: latest). 주면 API ordering으로 매핑됨 */
     sort?: SortValue;
     /** API ordering을 직접 지정하고 싶을 때(지정 시 sort보다 우선) */
-    // TODO: 태그 필터 추가
     ordering?: Ordering;
     search?: string;
   }
 ) {
   const pageSize = opts?.pageSize ?? LIST_SETTINGS.ITEMS_PER_PAGE;
 
-  // ordering이 오면 그걸 우선, 아니면 sort를 매핑, 둘 다 없으면 기본값
+  // ordering이 오면 우선, 없으면 sort 매핑, 둘 다 없으면 최신순
   const computedOrdering: Ordering =
     opts?.ordering ??
     (opts?.sort ? SORT_TO_ORDERING[opts.sort] : "-created_at");
 
-  return useInfiniteQuery<PostListItem[], Error>({
+  return useInfiniteQuery<PostListItem[], unknown>({
     queryKey: [
       "board-posts",
       board,
@@ -47,13 +47,27 @@ export function useBoardPosts(
       fetchPosts({
         board,
         ordering: computedOrdering,
-        page: pageParam as number,
+        page: pageParam as number, // DRF 1-base
         page_size: pageSize,
         search: opts?.search,
       }),
-    getNextPageParam: (lastPage, allPages) =>
-      lastPage.length === pageSize ? allPages.length + 1 : undefined,
+
+    // 마지막 페이지 길이가 pageSize보다 작으면 더 없음
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.length < pageSize) return undefined;
+      return allPages.length + 1; // 1, 2, 3...
+    },
+
+    // 404는 "끝" 신호 → 재시도/에러 전환 방지
+    retry: (failureCount, err) => {
+      const ae = err as AxiosError | undefined;
+      if (ae?.response?.status === 404) return false;
+      return failureCount < 2;
+    },
+
     staleTime: 0,
     gcTime: 5 * 60 * 1000,
+    // 필요하면 포커스 리패치 끄기:
+    // refetchOnWindowFocus: false,
   });
 }

--- a/src/hooks/useGithubPosts.ts
+++ b/src/hooks/useGithubPosts.ts
@@ -8,6 +8,7 @@ import { mapToGithubListItem } from "@src/features/posts/list/githubAdapter";
 import AssignedTagList from "@components/tags/AssignedTagList";
 import { adaptUserTag } from "@src/features/tags/adapters";
 import type { RawUserTag } from "@src/types/tag";
+import { LIST_SETTINGS } from "@src/constants/ui";
 
 // NOTE: 키 표시에만 사용 (API 파라미터는 github.ts에서 board id 사용)
 const GITHUB_BOARD_SLUG = "github" as const;
@@ -62,7 +63,7 @@ async function fetchGithubPage(
 }
 
 export function useGithubPosts(opt?: UseGithubPostsOptions) {
-  const pageSize = opt?.pageSize ?? DEFAULT_PAGE_SIZE;
+  const pageSize = opt?.pageSize ?? LIST_SETTINGS.ITEMS_PER_PAGE;
   const ordering = toOrdering(opt?.sort) ?? "-created_at";
 
   return useInfiniteQuery({

--- a/src/hooks/useGithubPosts.ts
+++ b/src/hooks/useGithubPosts.ts
@@ -9,13 +9,13 @@ import AssignedTagList from "@components/tags/AssignedTagList";
 import { adaptUserTag } from "@src/features/tags/adapters";
 import type { RawUserTag } from "@src/types/tag";
 import { LIST_SETTINGS } from "@src/constants/ui";
+import type { AxiosError } from "axios";
 
 // NOTE: 키 표시에만 사용 (API 파라미터는 github.ts에서 board id 사용)
 const GITHUB_BOARD_SLUG = "github" as const;
 
 // ---------------------------
 // TODO(sort): UI의 SortValue ↔ API ordering 매핑 표
-// useBoardPosts와 동일한 규약 유지
 export type SortValue = "latest" | "oldest" | "mostViewed" | "leastViewed";
 function toOrdering(
   v: SortValue | undefined
@@ -35,16 +35,12 @@ function toOrdering(
 }
 // ---------------------------
 
-// 훅 옵션(현재는 전부 optional, 미지정 시 현행 동작 유지)
-// TODO(filter): 태그/검색/정렬 연결 시 PostListPage, useBoardPosts와 동일 시그니처로 확장
 export type UseGithubPostsOptions = {
-  pageSize?: number; // default 10
+  pageSize?: number; // default LIST_SETTINGS.ITEMS_PER_PAGE
   sort?: SortValue; // default 'latest'
-  search?: string; // 검색어
-  tagIds?: number[]; // TODO(tags): 서버 태그 필터 파라미터 키 확인 후 적용
+  search?: string;
+  tagIds?: number[];
 };
-
-const DEFAULT_PAGE_SIZE = 10;
 
 type GithubPostsPage = { items: PostListItem[]; hasNext: boolean };
 
@@ -54,9 +50,8 @@ async function fetchGithubPage(
 ): Promise<GithubPostsPage> {
   return fetchGithubListPage({
     page,
-    page_size: opt?.pageSize ?? DEFAULT_PAGE_SIZE,
+    page_size: opt?.pageSize ?? LIST_SETTINGS.ITEMS_PER_PAGE,
     ordering: toOrdering(opt?.sort) ?? "-created_at",
-    // TODO(filter): search/tagIds 전달 (백엔드 파라미터 키 확정되면 아래 주석 해제)
     // search: opt?.search,
     // tags: opt?.tagIds,
   });
@@ -66,42 +61,57 @@ export function useGithubPosts(opt?: UseGithubPostsOptions) {
   const pageSize = opt?.pageSize ?? LIST_SETTINGS.ITEMS_PER_PAGE;
   const ordering = toOrdering(opt?.sort) ?? "-created_at";
 
-  return useInfiniteQuery({
-    // 키에 옵션 포함 (정렬/필터 변경 시 캐시 분리)
+  return useInfiniteQuery<GithubPostsPage, unknown>({
+    // 옵션 포함해서 캐시 분리
     queryKey: [
       "github-posts",
       {
         board: GITHUB_BOARD_SLUG,
         pageSize,
         ordering,
-        search: opt?.search,
-        tags: opt?.tagIds,
+        search: opt?.search ?? "",
+        tags: opt?.tagIds ?? [],
       },
     ] as const,
+
     initialPageParam: 1,
     queryFn: ({ pageParam }) => fetchGithubPage(pageParam as number, opt),
-    getNextPageParam: (lastPage, pages, lastParam) => {
-      if (!lastPage.hasNext) return undefined;
 
+    // 서버 hasNext 신뢰 + 방어적으로 길이 체크(배수 케이스 안전)
+    getNextPageParam: (lastPage, pages, lastParam) => {
+      if (!lastPage?.hasNext) return undefined;
+      if (!Array.isArray(lastPage.items) || lastPage.items.length < pageSize) {
+        return undefined;
+      }
+
+      // 중복 페이지 방지(같은 id 시퀀스가 연달아 오면 종료)
       const prev = pages[pages.length - 2] as GithubPostsPage | undefined;
       if (prev) {
         const a = prev.items.map((p) => p.id);
         const b = lastPage.items.map((p) => p.id);
-        if (a.length === b.length && a.every((v, i) => v === b[i]))
+        if (a.length === b.length && a.every((v, i) => v === b[i])) {
           return undefined;
+        }
       }
       return (lastParam as number) + 1;
     },
-    // 개발 중엔 필요 시 주석 해제
-    // retry: false,
+
+    // 404는 "끝" 신호로 간주 → 재시도/에러 전환 방지
+    retry: (failureCount, err) => {
+      const ae = err as AxiosError | undefined;
+      if (ae?.response?.status === 404) return false;
+      return failureCount < 2;
+    },
+
+    staleTime: 0,
+    gcTime: 5 * 60 * 1000,
+    // 필요 시:
     // refetchOnWindowFocus: false,
   });
 }
 
 /**
  * 리스트 아이템 변환 단계에서 tagSlot을 주입
- * - PostListItem에 user(오즈키 태그 원본)가 포함되어 있다면 AssignedTagList를 생성해 tagSlot에 넣음
- * - 포함되지 않았다면 tagSlot은 생략(상세에서만 태그 노출)
  */
 export function useGithubListItems(data?: InfiniteData<GithubPostsPage>) {
   const flat: PostListItem[] = useMemo(
@@ -156,7 +166,6 @@ export function useGithubListWithLinks(data?: InfiniteData<GithubPostsPage>): {
   }, []);
 
   useEffect(() => {
-    // TODO(perf): IntersectionObserver로 "화면에 들어온 카드"만 프리패치(성능 이슈 시)
     const targets = raw
       .filter(
         (it) =>

--- a/src/hooks/useSurveys.ts
+++ b/src/hooks/useSurveys.ts
@@ -7,6 +7,7 @@ import {
 } from "@src/features/posts/list/adapters";
 import { fetchSurveyExtra } from "@src/api/posts.special";
 import { LIST_SETTINGS } from "@src/constants/ui";
+import type { AxiosError } from "axios";
 
 export const SURVEYS_KEY = ["surveys"] as const;
 const PAGE_SIZE = LIST_SETTINGS.ITEMS_PER_PAGE;
@@ -14,40 +15,60 @@ const PAGE_SIZE = LIST_SETTINGS.ITEMS_PER_PAGE;
 type Page = { items: SurveyCardProps[]; hasMore: boolean; page: number };
 
 export function useSurveys() {
-  return useInfiniteQuery<Page>({
-    queryKey: SURVEYS_KEY,
+  return useInfiniteQuery<Page, unknown>({
+    // 페이지 크기 등이 바뀌면 캐시 키 분리되도록 포함
+    queryKey: [...SURVEYS_KEY, { pageSize: PAGE_SIZE }],
     initialPageParam: 1,
+
     queryFn: async ({ pageParam }) => {
-      // 1) 기본 목록 불러오기
+      // 1) 기본 목록
       const list = await fetchPosts({
         board: "survey",
         ordering: "-created_at",
-        page: pageParam as number,
+        page: pageParam as number, // DRF 1-base
         page_size: PAGE_SIZE,
       });
 
-      // 2) 각 아이템의 설문 부가정보를 병렬로 불러서 맵으로 만든다
-      const extrasArr = await Promise.all(
-        list.map(async (p) => {
-          try {
-            const ex = await fetchSurveyExtra(p.id);
-            return [p.id, ex] as [number, SurveyExtra];
-          } catch {
-            return [p.id, {}] as [number, SurveyExtra];
-          }
-        })
-      );
-      const extrasMap = new Map<number, SurveyExtra>(extrasArr);
+      // 2) 부가정보 병렬 요청 (빈 목록이면 생략)
+      const extrasMap =
+        list.length === 0
+          ? new Map<number, SurveyExtra>()
+          : new Map<number, SurveyExtra>(
+              await Promise.all(
+                list.map(async (p) => {
+                  try {
+                    const ex = await fetchSurveyExtra(p.id);
+                    return [p.id, ex] as [number, SurveyExtra];
+                  } catch {
+                    return [p.id, {}] as [number, SurveyExtra];
+                  }
+                })
+              )
+            );
 
-      // 3) SurveyCardProps로 매핑(+ extras 합치기)
+      // 3) UI 매핑
       const items = list.map((p) => mapToSurveyCard(p, extrasMap.get(p.id)));
 
       return {
         items,
-        hasMore: list.length === PAGE_SIZE,
+        // 마지막 페이지 길이가 PAGE_SIZE 미만이면 불러올 것 더 없음
+        hasMore: items.length >= PAGE_SIZE,
         page: pageParam as number,
       };
     },
+
+    // hasMore 기반 다음 페이지 계산
     getNextPageParam: (last) => (last.hasMore ? last.page + 1 : undefined),
+
+    // 404는 "끝" 신호로 보고 재시도/에러 전환 방지
+    retry: (failureCount, err) => {
+      const ae = err as AxiosError | undefined;
+      if (ae?.response?.status === 404) return false;
+      return failureCount < 2;
+    },
+
+    staleTime: 0,
+    gcTime: 5 * 60 * 1000,
+    // 필요 시: refetchOnWindowFocus: false,
   });
 }


### PR DESCRIPTION
# 이슈 원인
- 서버(DRF)는 더 이상 데이터가 없을 때 404를 반환
- 무한 스크롤 시 마지막 페이지 이후 클라이언트가 다음 페이지(N+1)를 한 번 더 요청 -> 404 반환

# 조치 사항
## 1. posts.ts의 fetchPosts 수정
- try/catch 추가하여, 404 수신 시 빈 배열 반환 + "더 불러올 데이터 없음"으로 명확한 안내
- 에러 타입을 unknown → AxiosError 캐스팅으로 안전하게 처리.
- 서버 측의 에러 메시지는 클라이언트에서 조치 취할 수 없어 수정 보류

## 2. 각 게시판별 hook에서의 처리(훅 내 useInfiniteQuery 수정)
- `LIST_SETTINGS.ITEMS_PER_PAGE`로 마지막 페이지 여부 판단 (lastPage.length < pageSize → 종료)
- 404를 끝 신호로 수용 → 재시도/에러 전환 방지

---

closes #171 