### PR TITLE
[feat] 태그 필터 UI (포지션-라디오 / 기수-슬라이더)

### DIFF
--- a/src/components/Board/common/BoardTopBar.tsx
+++ b/src/components/Board/common/BoardTopBar.tsx
@@ -10,6 +10,7 @@ type Props = {
   meta?: React.ReactNode;
   className?: string;
   sortButtonRef?: React.Ref<HTMLButtonElement>;
+  tagButtonRef?: React.Ref<HTMLButtonElement>;
   sortActive?: boolean;
 };
 
@@ -21,6 +22,7 @@ export default function BoardTopBar({
   meta,
   className,
   sortButtonRef,
+  tagButtonRef,
   sortActive,
 }: Props) {
   return (
@@ -42,6 +44,7 @@ export default function BoardTopBar({
             className="h-9 w-9 p-2 max-[380px]:size-7 max-[380px]:p-1"
           />
           <FilterIconButton
+            ref={tagButtonRef}
             kind="tag"
             onClick={onOpenTag}
             className="h-9 w-9 p-2 max-[380px]:size-7 max-[380px]:p-1"

--- a/src/components/Board/common/BoardTopBar.tsx
+++ b/src/components/Board/common/BoardTopBar.tsx
@@ -12,6 +12,7 @@ type Props = {
   sortButtonRef?: React.Ref<HTMLButtonElement>;
   tagButtonRef?: React.Ref<HTMLButtonElement>;
   sortActive?: boolean;
+  tagActive?: boolean;
 };
 
 export default function BoardTopBar({
@@ -24,6 +25,7 @@ export default function BoardTopBar({
   sortButtonRef,
   tagButtonRef,
   sortActive,
+  tagActive,
 }: Props) {
   return (
     <div className={`space-y-0.5 ${className ?? ""}`}>
@@ -46,6 +48,7 @@ export default function BoardTopBar({
           <FilterIconButton
             ref={tagButtonRef}
             kind="tag"
+            active={tagActive}
             onClick={onOpenTag}
             className="h-9 w-9 p-2 max-[380px]:size-7 max-[380px]:p-1"
           />

--- a/src/components/Board/common/tagfilter/CohortSlider.tsx
+++ b/src/components/Board/common/tagfilter/CohortSlider.tsx
@@ -1,0 +1,61 @@
+import { useCallback } from "react";
+
+export default function CohortSlider({
+  value,
+  min = 1,
+  max = 20,
+  onChange,
+  onReset,
+  className = "",
+  label = "기수 필터",
+}: {
+  value: number;
+  min?: number;
+  max?: number;
+  onChange: (v: number) => void;
+  onReset?: () => void;
+  className?: string;
+  label?: string;
+}) {
+  const handle = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+    (e) => onChange(Number(e.target.value)),
+    [onChange]
+  );
+
+  return (
+    <div className={className}>
+      <div className="mb-2 text-sm text-base-content/70">{label}</div>
+
+      {/* 양 끝 라벨 */}
+      <div className="flex items-center justify-between text-xs text-base-content/60 mb-2">
+        <span>{min}기</span>
+        <span>{max}기</span>
+      </div>
+
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={1}
+        value={value}
+        onChange={handle}
+        className="range range-primary"
+        aria-label={label}
+      />
+
+      {/* 현재 값 라벨 */}
+      <div className="mt-2 flex items-center justify-between">
+        <span className="text-sm font-medium">{value}기</span>
+        {onReset && (
+          <button
+            type="button"
+            onClick={onReset}
+            className="text-primary text-sm hover:underline"
+          >
+            초기화
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Board/common/tagfilter/CohortSlider.tsx
+++ b/src/components/Board/common/tagfilter/CohortSlider.tsx
@@ -23,10 +23,9 @@ export default function CohortSlider({
   );
 
   return (
-    <div className={className}>
-      <div className="mb-2 text-sm text-base-content/70">{label}</div>
+    <div className={["px-1", className].join(" ")}>
+      <div className="text-xs text-base-content/60 mb-2">{label}</div>
 
-      {/* 양 끝 라벨 */}
       <div className="flex items-center justify-between text-xs text-base-content/60 mb-2">
         <span>{min}기</span>
         <span>{max}기</span>
@@ -43,7 +42,6 @@ export default function CohortSlider({
         aria-label={label}
       />
 
-      {/* 현재 값 라벨 */}
       <div className="mt-2 flex items-center justify-between">
         <span className="text-sm font-medium">{value}기</span>
         {onReset && (

--- a/src/components/Board/common/tagfilter/PositionRadio.tsx
+++ b/src/components/Board/common/tagfilter/PositionRadio.tsx
@@ -1,0 +1,85 @@
+import { useId, useMemo } from "react";
+
+export type PositionValue = "front" | "back" | "startup" | "design";
+
+type Option = { value: PositionValue; label: string; disabled?: boolean };
+
+export default function PositionRadio({
+  value,
+  onChange,
+  className = "",
+  groupLabel = "포지션 필터",
+  options,
+}: {
+  value: PositionValue;
+  onChange: (v: PositionValue) => void;
+  className?: string;
+  groupLabel?: string;
+  options?: Option[];
+}) {
+  const groupId = useId();
+
+  const OPS = useMemo<Option[]>(
+    () =>
+      options ?? [
+        { value: "front", label: "프론트엔드" },
+        { value: "back", label: "백엔드" },
+        { value: "startup", label: "창업" },
+        { value: "design", label: "디자인" },
+      ],
+    [options]
+  );
+
+  return (
+    <div className={className}>
+      <span id={groupId} className="sr-only">
+        {groupLabel}
+      </span>
+
+      <div
+        role="radiogroup"
+        aria-labelledby={groupId}
+        className="grid grid-cols-2 gap-2 md:grid-cols-4 md:gap-3"
+      >
+        {OPS.map((o) => {
+          const selected = o.value === value;
+          return (
+            <button
+              key={o.value}
+              role="radio"
+              aria-checked={selected}
+              aria-disabled={o.disabled || undefined}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => !o.disabled && onChange(o.value)}
+              className={[
+                "w-full h-9 px-3 rounded-xl transition flex items-center gap-2 justify-start",
+                "border border-base-300 hover:border-base-200",
+                o.disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
+                "text-base-content",
+              ].join(" ")}
+            >
+              <span
+                aria-hidden
+                className={[
+                  "flex items-center justify-center size-4 rounded-full border shrink-0",
+                  selected ? "border-primary" : "border-base-300",
+                ].join(" ")}
+              >
+                <span
+                  className={[
+                    "block rounded-full size-2",
+                    selected ? "bg-primary" : "bg-transparent",
+                  ].join(" ")}
+                />
+              </span>
+              <span className="text-sm whitespace-nowrap break-keep">
+                {o.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Board/common/tagfilter/PositionRadio.tsx
+++ b/src/components/Board/common/tagfilter/PositionRadio.tsx
@@ -1,7 +1,6 @@
 import { useId, useMemo } from "react";
 
 export type PositionValue = "front" | "back" | "startup" | "design";
-
 type Option = { value: PositionValue; label: string; disabled?: boolean };
 
 export default function PositionRadio({
@@ -23,8 +22,8 @@ export default function PositionRadio({
     () =>
       options ?? [
         { value: "front", label: "프론트엔드" },
-        { value: "back", label: "백엔드" },
         { value: "startup", label: "창업" },
+        { value: "back", label: "백엔드" },
         { value: "design", label: "디자인" },
       ],
     [options]
@@ -39,7 +38,7 @@ export default function PositionRadio({
       <div
         role="radiogroup"
         aria-labelledby={groupId}
-        className="grid grid-cols-2 gap-2 md:grid-cols-4 md:gap-3"
+        className="grid grid-cols-2 gap-3"
       >
         {OPS.map((o) => {
           const selected = o.value === value;
@@ -53,7 +52,6 @@ export default function PositionRadio({
               onClick={() => !o.disabled && onChange(o.value)}
               className={[
                 "w-full h-9 px-3 rounded-xl transition flex items-center gap-2 justify-start",
-                "border border-base-300 hover:border-base-200",
                 o.disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
                 "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/60",
                 "text-base-content",

--- a/src/components/Board/common/tagfilter/TagFilterPopover.tsx
+++ b/src/components/Board/common/tagfilter/TagFilterPopover.tsx
@@ -1,0 +1,182 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useCallback,
+} from "react";
+import { createPortal } from "react-dom";
+import PositionRadio, { type PositionValue } from "./PositionRadio";
+import CohortSlider from "./CohortSlider";
+
+type Props = {
+  open: boolean;
+  anchorRef: React.RefObject<HTMLButtonElement | null>;
+  position: PositionValue;
+  cohort: number;
+  onChangePosition: (v: PositionValue) => void;
+  onChangeCohort: (v: number) => void;
+  onReset?: () => void; // 전체 초기화(옵션)
+  onApply?: () => void; // 적용 버튼(옵션)
+  onRequestClose: () => void; // 바깥 클릭/ESC/스크롤 등 닫힘
+};
+
+const GAP = 8;
+const MARGIN = 12;
+
+export default function TagFilterPopover({
+  open,
+  anchorRef,
+  position,
+  cohort,
+  onChangePosition,
+  onChangeCohort,
+  onReset,
+  onApply,
+  onRequestClose,
+}: Props) {
+  const popRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  // 위치 계산
+  useLayoutEffect(() => {
+    if (!open || !anchorRef.current) return;
+    const id = requestAnimationFrame(() => {
+      const a = anchorRef.current!;
+      const pr = popRef.current?.getBoundingClientRect();
+      const ar = a.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const width = pr?.width ?? 280;
+
+      let left = ar.left;
+      left = Math.max(MARGIN, Math.min(left, vw - MARGIN - width));
+      const top = ar.bottom + GAP;
+
+      setPos({ top, left });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [open, anchorRef, position, cohort]);
+
+  // 바깥 클릭 / ESC 닫기
+  useEffect(() => {
+    if (!open) return;
+
+    const onDoc = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (!popRef.current) return;
+      if (!popRef.current.contains(t) && !anchorRef.current?.contains(t)) {
+        onRequestClose();
+      }
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onRequestClose();
+    };
+
+    document.addEventListener("mousedown", onDoc, true);
+    document.addEventListener("keydown", onEsc);
+    return () => {
+      document.removeEventListener("mousedown", onDoc, true);
+      document.removeEventListener("keydown", onEsc);
+    };
+  }, [open, onRequestClose, anchorRef]);
+
+  // 창/스크롤/휠/터치/탭전환/앵커소실 → 닫기
+  useEffect(() => {
+    if (!open) return;
+    const close = () => onRequestClose();
+    const opts = { passive: true } as const;
+
+    window.addEventListener("resize", close, opts);
+    window.addEventListener("orientationchange", close, opts);
+    window.addEventListener("scroll", close, opts);
+    window.addEventListener("wheel", close, opts);
+    window.addEventListener("touchmove", close, opts);
+    const onVisibility = () => document.hidden && close();
+    document.addEventListener("visibilitychange", onVisibility);
+
+    const mo = new MutationObserver(() => {
+      if (!anchorRef.current || !document.body.contains(anchorRef.current))
+        close();
+    });
+    if (anchorRef.current) {
+      mo.observe(document.body, { childList: true, subtree: true });
+    }
+
+    return () => {
+      window.removeEventListener("resize", close);
+      window.removeEventListener("orientationchange", close);
+      window.removeEventListener("scroll", close);
+      window.removeEventListener("wheel", close);
+      window.removeEventListener("touchmove", close);
+      document.removeEventListener("visibilitychange", onVisibility);
+      mo.disconnect();
+    };
+  }, [open, onRequestClose, anchorRef]);
+
+  const handleApply = useCallback(() => {
+    onApply?.();
+    onRequestClose();
+  }, [onApply, onRequestClose]);
+
+  if (!open || !anchorRef.current) return null;
+
+  const node = (
+    <>
+      {/* ✨ 오버레이 (cursor: default) */}
+      <div
+        aria-hidden
+        className="fixed inset-0 z-40 bg-black/0 cursor-default"
+        onMouseDown={onRequestClose}
+      />
+      <div
+        ref={popRef}
+        style={{
+          position: "fixed",
+          top: pos?.top ?? -9999,
+          left: pos?.left ?? -9999,
+          zIndex: 50,
+        }}
+        className="rounded-2xl shadow-xl border border-base-300 bg-base-100 p-3 w-[280px]"
+      >
+        <div className="px-1 text-xs text-base-content/60 mb-2">
+          포지션 필터
+        </div>
+        <PositionRadio value={position} onChange={onChangePosition} />
+
+        <div className="mt-4">
+          <CohortSlider
+            value={cohort}
+            min={1}
+            max={20}
+            onChange={onChangeCohort}
+          />
+        </div>
+
+        {(onApply || onReset) && (
+          <div className="mt-4 flex items-center justify-end gap-2">
+            {onReset && (
+              <button
+                type="button"
+                onClick={onReset}
+                className="btn btn-ghost btn-sm"
+              >
+                초기화
+              </button>
+            )}
+            {onApply && (
+              <button
+                type="button"
+                onClick={handleApply}
+                className="btn btn-primary btn-sm"
+              >
+                적용
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+
+  return createPortal(node, document.body);
+}

--- a/src/components/Board/common/tagfilter/TagFilterPopover.tsx
+++ b/src/components/Board/common/tagfilter/TagFilterPopover.tsx
@@ -12,13 +12,16 @@ import CohortSlider from "./CohortSlider";
 type Props = {
   open: boolean;
   anchorRef: React.RefObject<HTMLButtonElement | null>;
-  position: PositionValue;
-  cohort: number;
+  position: PositionValue; // 커밋된 값(읽기 전용처럼 취급)
+  cohort: number; // 커밋된 값(읽기 전용처럼 취급)
   onChangePosition: (v: PositionValue) => void;
   onChangeCohort: (v: number) => void;
-  onReset?: () => void; // 전체 초기화(옵션)
-  onApply?: () => void; // 적용 버튼(옵션)
-  onRequestClose: () => void; // 바깥 클릭/ESC/스크롤 등 닫힘
+  onReset?: () => void; // (옵션) 외부 초기화 버튼이 따로 있을 때만 사용
+  onApply?: () => void; // (옵션) 적용 알림만 필요하면 사용
+  onRequestClose: () => void; // 닫힘
+  // (선택) 내부 초기화 기본값 — 없으면 back/11로 처리
+  defaultPosition?: PositionValue;
+  defaultCohort?: number;
 };
 
 const GAP = 8;
@@ -31,12 +34,26 @@ export default function TagFilterPopover({
   cohort,
   onChangePosition,
   onChangeCohort,
-  onReset,
+  // onReset,           // 외부 상태를 즉시 바꾸지 않도록 이 컴포넌트에서는 호출하지 않음
   onApply,
   onRequestClose,
+  defaultPosition = "back",
+  defaultCohort = 11,
 }: Props) {
   const popRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  // 내부 draft 상태
+  const [draftPosition, setDraftPosition] = useState<PositionValue>(position);
+  const [draftCohort, setDraftCohort] = useState<number>(cohort);
+
+  // 팝오버가 열릴 때마다 현재 커밋 값으로 draft 초기화
+  useEffect(() => {
+    if (open) {
+      setDraftPosition(position);
+      setDraftCohort(cohort);
+    }
+  }, [open, position, cohort]);
 
   // 위치 계산
   useLayoutEffect(() => {
@@ -55,9 +72,9 @@ export default function TagFilterPopover({
       setPos({ top, left });
     });
     return () => cancelAnimationFrame(id);
-  }, [open, anchorRef, position, cohort]);
+  }, [open, anchorRef, draftPosition, draftCohort]);
 
-  // 바깥 클릭 / ESC 닫기
+  // 바깥 클릭 / ESC 닫기 (적용 없음 = draft 폐기)
   useEffect(() => {
     if (!open) return;
 
@@ -80,7 +97,7 @@ export default function TagFilterPopover({
     };
   }, [open, onRequestClose, anchorRef]);
 
-  // 창/스크롤/휠/터치/탭전환/앵커소실 → 닫기
+  // 창/스크롤 등 닫기
   useEffect(() => {
     if (!open) return;
     const close = () => onRequestClose();
@@ -113,10 +130,26 @@ export default function TagFilterPopover({
     };
   }, [open, onRequestClose, anchorRef]);
 
+  // 적용 시에만 상위 콜백 호출
   const handleApply = useCallback(() => {
+    onChangePosition(draftPosition);
+    onChangeCohort(draftCohort);
     onApply?.();
     onRequestClose();
-  }, [onApply, onRequestClose]);
+  }, [
+    draftPosition,
+    draftCohort,
+    onChangePosition,
+    onChangeCohort,
+    onApply,
+    onRequestClose,
+  ]);
+
+  // 초기화는 draft만 리셋 (외부 상태는 건들지 않음)
+  const handleReset = useCallback(() => {
+    setDraftPosition(defaultPosition);
+    setDraftCohort(defaultCohort);
+  }, [defaultPosition, defaultCohort]);
 
   if (!open || !anchorRef.current) return null;
 
@@ -141,39 +174,33 @@ export default function TagFilterPopover({
         <div className="px-1 text-xs text-base-content/60 mb-2">
           포지션 필터
         </div>
-        <PositionRadio value={position} onChange={onChangePosition} />
+        <PositionRadio value={draftPosition} onChange={setDraftPosition} />
 
         <div className="mt-8">
           <CohortSlider
-            value={cohort}
+            value={draftCohort}
             min={1}
             max={20}
-            onChange={onChangeCohort}
+            onChange={setDraftCohort}
           />
         </div>
 
-        {(onApply || onReset) && (
-          <div className="mt-4 flex items-center justify-end gap-2">
-            {onReset && (
-              <button
-                type="button"
-                onClick={onReset}
-                className="btn btn-ghost btn-sm"
-              >
-                초기화
-              </button>
-            )}
-            {onApply && (
-              <button
-                type="button"
-                onClick={handleApply}
-                className="btn btn-primary btn-sm text-white"
-              >
-                적용
-              </button>
-            )}
-          </div>
-        )}
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="btn btn-ghost btn-sm"
+          >
+            초기화
+          </button>
+          <button
+            type="button"
+            onClick={handleApply}
+            className="btn btn-primary btn-sm text-white"
+          >
+            적용
+          </button>
+        </div>
       </div>
     </>
   );

--- a/src/components/Board/common/tagfilter/TagFilterPopover.tsx
+++ b/src/components/Board/common/tagfilter/TagFilterPopover.tsx
@@ -122,7 +122,7 @@ export default function TagFilterPopover({
 
   const node = (
     <>
-      {/* ✨ 오버레이 (cursor: default) */}
+      {/* 오버레이 */}
       <div
         aria-hidden
         className="fixed inset-0 z-40 bg-black/0 cursor-default"
@@ -143,7 +143,7 @@ export default function TagFilterPopover({
         </div>
         <PositionRadio value={position} onChange={onChangePosition} />
 
-        <div className="mt-4">
+        <div className="mt-8">
           <CohortSlider
             value={cohort}
             min={1}
@@ -167,7 +167,7 @@ export default function TagFilterPopover({
               <button
                 type="button"
                 onClick={handleApply}
-                className="btn btn-primary btn-sm"
+                className="btn btn-primary btn-sm text-white"
               >
                 적용
               </button>

--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -7,7 +7,9 @@ import PostRow, { type FreeBoardItem, FREE_LIST_GRID } from "./PostRow";
 import { LastLoadedBar, BoardTopBar } from "../common";
 import { useRef, useState, type ReactNode } from "react";
 import SortRadioPopover from "@components/Board/common/sort/SortRadioPopover";
+import TagFilterPopover from "@components/Board/common/tagfilter/TagFilterPopover";
 import type { SortValue } from "@src/types/sort";
+import type { PositionValue } from "@components/Board/common/tagfilter/PositionRadio";
 import { ERROR_MESSAGES, LIST_MESSAGES, LOADING_MESSAGES } from "@constants/ui";
 
 export type PostListProps = {
@@ -58,10 +60,18 @@ export default function PostList({
   scrollRootRef,
   renderAuthorLabel,
 }: PostListProps) {
+  // ------ 정렬(UI) ------
   const sortBtnRef = useRef<HTMLButtonElement>(null);
   const [openSort, setOpenSort] = useState(false);
   const [sort, setSort] = useState<SortValue>("latest"); // UI 전용
   const sortActive = sort !== "latest";
+
+  // ------ 태그(UI) ------
+  const tagBtnRef = useRef<HTMLButtonElement>(null);
+  const [openTag, setOpenTag] = useState(false);
+  const [position, setPosition] = useState<PositionValue>("back");
+  const [cohort, setCohort] = useState<number>(11);
+  const tagActive = position !== "back" || cohort !== 11;
 
   const isEmpty = items.length === 0;
 
@@ -71,10 +81,11 @@ export default function PostList({
         <BoardTopBar
           boardName={topBar.boardName}
           onOpenSort={() => setOpenSort((v) => !v)}
-          onOpenTag={topBar.onOpenTag}
+          onOpenTag={() => setOpenTag((v) => !v)}
           onWrite={topBar.onWrite}
           sortButtonRef={sortBtnRef}
-          sortActive={sortActive}
+          tagButtonRef={tagBtnRef}
+          sortActive={sortActive || tagActive} // TODO: 필요시 분리
           className="mb-2 px-3 flex-none"
           meta={
             <LastLoadedBar
@@ -185,6 +196,25 @@ export default function PostList({
         value={sort}
         onChange={(v) => setSort(v)}
         onRequestClose={() => setOpenSort(false)}
+      />
+
+      {/* 태그 팝오버 (UI) */}
+      <TagFilterPopover
+        open={openTag}
+        anchorRef={tagBtnRef}
+        position={position}
+        cohort={cohort}
+        onChangePosition={setPosition}
+        onChangeCohort={setCohort}
+        onReset={() => {
+          setPosition("back");
+          setCohort(11);
+        }}
+        onApply={() => {
+          // UI 전용: 여기서는 fetch 안 함
+          // TODO: 실제 연동 시 상위(PostListPage)에서 상태를 들고 있다가 refetch + lastLoadedAt 갱신하면 됨
+        }}
+        onRequestClose={() => setOpenTag(false)}
       />
     </section>
   );

--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -85,7 +85,8 @@ export default function PostList({
           onWrite={topBar.onWrite}
           sortButtonRef={sortBtnRef}
           tagButtonRef={tagBtnRef}
-          sortActive={sortActive || tagActive} // TODO: 필요시 분리
+          sortActive={sortActive}
+          tagActive={tagActive}
           className="mb-2 px-3 flex-none"
           meta={
             <LastLoadedBar

--- a/src/components/Board/github/GithubList.tsx
+++ b/src/components/Board/github/GithubList.tsx
@@ -4,6 +4,8 @@ import GithubCard, { type GithubCardProps } from "./GithubCard";
 import { useRef, useState } from "react";
 import SortRadioPopover from "@components/Board/common/sort/SortRadioPopover";
 import type { SortValue } from "@src/types/sort";
+import TagFilterPopover from "@components/Board/common/tagfilter/TagFilterPopover";
+import type { PositionValue } from "@components/Board/common/tagfilter/PositionRadio";
 import { LIST_MESSAGES } from "@src/constants/ui";
 
 export type GithubListItem = GithubCardProps;
@@ -55,9 +57,18 @@ export default function GithubList({
   scrollRootRef,
 }: GithubListProps) {
   const isEmpty = items.length === 0;
+
+  // ------ 정렬(UI) ------
   const sortBtnRef = useRef<HTMLButtonElement>(null);
   const [openSort, setOpenSort] = useState(false);
   const [sort, setSort] = useState<SortValue>("latest");
+
+  // ------ 태그(UI) ------
+  const tagBtnRef = useRef<HTMLButtonElement>(null);
+  const [openTag, setOpenTag] = useState(false);
+  const [position, setPosition] = useState<PositionValue>("back");
+  const [cohort, setCohort] = useState<number>(11);
+  const tagActive = position !== "back" || cohort !== 11;
 
   return (
     <section className={`flex h-full flex-col ${className ?? ""}`}>
@@ -65,10 +76,12 @@ export default function GithubList({
         <BoardTopBar
           boardName={topBar.boardName}
           onOpenSort={() => setOpenSort((v) => !v)}
-          onOpenTag={topBar.onOpenTag}
+          onOpenTag={() => setOpenTag((v) => !v)}
           onWrite={topBar.onWrite}
           sortButtonRef={sortBtnRef}
           sortActive={sort !== "latest"}
+          tagButtonRef={tagBtnRef}
+          tagActive={tagActive}
           className="mb-2 px-3 flex-none"
           meta={
             <LastLoadedBar
@@ -144,6 +157,24 @@ export default function GithubList({
         value={sort}
         onChange={(v) => setSort(v)}
         onRequestClose={() => setOpenSort(false)}
+      />
+
+      {/* 태그 팝오버(UI) */}
+      <TagFilterPopover
+        open={openTag}
+        anchorRef={tagBtnRef}
+        position={position}
+        cohort={cohort}
+        onChangePosition={setPosition}
+        onChangeCohort={setCohort}
+        onReset={() => {
+          setPosition("front");
+          setCohort(11);
+        }}
+        onApply={() => {
+          // UI 전용: 실제 refetch/lastLoadedAt 갱신은 상위로 승격할 때 연결
+        }}
+        onRequestClose={() => setOpenTag(false)}
       />
     </section>
   );

--- a/src/components/Board/github/GithubList.tsx
+++ b/src/components/Board/github/GithubList.tsx
@@ -168,7 +168,7 @@ export default function GithubList({
         onChangePosition={setPosition}
         onChangeCohort={setCohort}
         onReset={() => {
-          setPosition("front");
+          setPosition("back");
           setCohort(11);
         }}
         onApply={() => {

--- a/src/components/Board/survey/SurveyList.tsx
+++ b/src/components/Board/survey/SurveyList.tsx
@@ -160,7 +160,7 @@ export default function SurveyList({
         onChangePosition={setPosition}
         onChangeCohort={setCohort}
         onReset={() => {
-          setPosition("front");
+          setPosition("back");
           setCohort(11);
         }}
         onApply={() => {

--- a/src/components/Board/survey/SurveyList.tsx
+++ b/src/components/Board/survey/SurveyList.tsx
@@ -5,6 +5,8 @@ import { LastLoadedBar, BoardTopBar } from "../common";
 import { useRef, useState } from "react";
 import SortRadioPopover from "@components/Board/common/sort/SortRadioPopover";
 import type { SortValue } from "@src/types/sort";
+import TagFilterPopover from "@components/Board/common/tagfilter/TagFilterPopover";
+import type { PositionValue } from "@components/Board/common/tagfilter/PositionRadio";
 import { LIST_MESSAGES } from "@src/constants/ui";
 
 export type SurveyListProps = {
@@ -53,20 +55,31 @@ export default function SurveyList({
   scrollRootRef,
 }: SurveyListProps) {
   const isEmpty = items.length === 0;
+
+  // ------ 정렬(UI) ------
   const sortBtnRef = useRef<HTMLButtonElement>(null);
   const [openSort, setOpenSort] = useState(false);
-  const [sort, setSort] = useState<SortValue>("latest"); // 기본값: 최신
+  const [sort, setSort] = useState<SortValue>("latest"); // UI 전용
+
+  // ------ 태그(UI) ------
+  const tagBtnRef = useRef<HTMLButtonElement>(null);
+  const [openTag, setOpenTag] = useState(false);
+  const [position, setPosition] = useState<PositionValue>("back");
+  const [cohort, setCohort] = useState<number>(11);
+  const tagActive = position !== "back" || cohort !== 11;
 
   return (
     <section className={`flex h-full flex-col ${className ?? ""}`}>
       {topBar && (
         <BoardTopBar
           boardName={topBar.boardName}
-          onOpenSort={() => setOpenSort((v) => !v)} // 로컬 토글
-          onOpenTag={topBar.onOpenTag}
+          onOpenSort={() => setOpenSort((v) => !v)}
+          onOpenTag={() => setOpenTag((v) => !v)}
           onWrite={topBar.onWrite}
           sortButtonRef={sortBtnRef}
           sortActive={sort !== "latest"}
+          tagButtonRef={tagBtnRef}
+          tagActive={tagActive}
           className="mb-2 px-3 flex-none"
           meta={
             <LastLoadedBar
@@ -136,6 +149,25 @@ export default function SurveyList({
         value={sort}
         onChange={(v) => setSort(v)} // 지금은 상태만 변경
         onRequestClose={() => setOpenSort(false)}
+      />
+
+      {/* 태그 팝오버 추가 */}
+      <TagFilterPopover
+        open={openTag}
+        anchorRef={tagBtnRef}
+        position={position}
+        cohort={cohort}
+        onChangePosition={setPosition}
+        onChangeCohort={setCohort}
+        onReset={() => {
+          setPosition("front");
+          setCohort(11);
+        }}
+        onApply={() => {
+          // UI 전용: 실제 fetch/refetch는 상위 승격 시 연결
+          // (PostList에서 쓰던 패턴 그대로)
+        }}
+        onRequestClose={() => setOpenTag(false)}
       />
     </section>
   );


### PR DESCRIPTION
전 게시판에서 보실 수 있습니다.
디폴트 - 백엔드, 11기
디폴트 외 값 적용 시 활성화 점 표시됩니다.
esc, 창 크기 줄임, 스크롤 등 반응하여 닫힙니다.
적용을 누르지 않고 닫혔을 때엔 변경사항 적용이 되지 아니합니다.


<img width="394" height="408" alt="image" src="https://github.com/user-attachments/assets/5c2b8a70-66d9-4185-9718-4f0c8ae02dc3" />
<img width="398" height="417" alt="image" src="https://github.com/user-attachments/assets/9f26f50a-6dd7-4b21-ad99-6c719afbbcf4" />
<img width="377" height="423" alt="image" src="https://github.com/user-attachments/assets/b6773337-c2fb-4ec2-844c-d4a9e535f305" />

---

closes #54 