### PR TITLE
[fix] 상세 페이지에 메인 레이아웃 추가

### DIFF
--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -13,7 +13,7 @@ export const PATHS = {
   GITHUB_BOARD: "/board/github",
 
   // 게시글
-  POST_DETAIL: "/board/:board/post/:id",
+  POST_DETAIL: "/posts/:id",
   POST_CREATE: "/write", // 쿼리로 board 구분
   POST_EDIT: "/post/:id/edit",
 

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -118,7 +118,7 @@ function KeyVerifyPlaceholder() {
     } catch (err: unknown) {
       const msg =
         typeof err === "object" && err && "message" in err
-          ? ((err as { message?: string }).message ?? "인증 실패")
+          ? (err as { message?: string }).message ?? "인증 실패"
           : "인증 실패";
       push({ message: msg, type: "error" });
     }
@@ -291,10 +291,9 @@ export default function AppRouter() {
             element={<PostListPage board="info" />}
           />
           <Route path={PATHS.SURVEY_BOARD} element={<SurveyListPage />} />
-
           <Route path={PATHS.GITHUB_BOARD} element={<GithubListPage />} />
-          <Route path={PATHS.POST_CREATE} element={<WritePostPage />} />
           <Route path={PATHS.POST_DETAIL} element={<PostDetailPage />} />
+          <Route path={PATHS.POST_CREATE} element={<WritePostPage />} />
 
           {/* 보호: 마이페이지 (JWT + 인증 완료) */}
           <Route


### PR DESCRIPTION
상세 페이지에 메인 레이아웃을 추가하면서 상세 페이지를 올바른 경로로 수정해주었음에도
메인 레이아웃이 적용되지 않는 버그가 발견되었습니다..
앞서 라우팅되어 있던 API 테스트 라우트가 먼저 매칭되어 상세페이지 레이아웃이 안뜨는 문제였으며,
해당 라우팅은 삭제한 상태입니다.
<img width="1445" height="1068" alt="image" src="https://github.com/user-attachments/assets/1abd170c-7746-4442-85b3-ea57590d2dc2" />


closes #176