### PR TITLE
[fix] 설문/깃헙 게시판에서 상세페이지로 넘어가는 경로 설정

### DIFF
--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -69,7 +69,7 @@ export default function GithubListPage() {
       <section className="w-full rounded-xl border border-base-content/30 p-3 pb-8 h-[calc(100vh-200px)] overflow-hidden">
         <GithubList
           items={items}
-          onItemClick={(id) => nav(urlForPost.postDetail("github", id))}
+          onItemClick={(id) => nav(`/posts/${id}`)}
           onRepoClick={onRepoClick}
           topBar={{
             boardName: "GitHub 게시판",

--- a/src/pages/boards/SurveyListPage.tsx
+++ b/src/pages/boards/SurveyListPage.tsx
@@ -76,7 +76,7 @@ export default function SurveyListPage() {
       <section className="w-full rounded-xl border border-base-content/30 p-3 pb-8 h-[calc(100vh-200px)] overflow-hidden">
         <SurveyList
           items={sortedItems}
-          onItemClick={(id) => nav(urlForPost.postDetail("survey", id))}
+          onItemClick={(id) => nav(`/posts/${id}`)}
           topBar={{
             boardName: "설문 게시판",
             onOpenTag: () => {}, // TODO[UI→API-TAGS]: 태그 필터를 훅/서버에 연결


### PR DESCRIPTION
경로 수정 완료했습니다.
onItemClick={(id) => nav(`/posts/${id}\`)}

잘 작동합니다.

closes #180 