### PR TITLE
[feat] 게시글 상세 페이지 타이틀 수정

### DIFF
--- a/src/components/Post/PostDetail.tsx
+++ b/src/components/Post/PostDetail.tsx
@@ -26,7 +26,7 @@ import type { RawUserTag } from "@api/tags";
 import AssignedTagList from "../tags/AssignedTagList";
 import { RepoPreviewCard } from "../Board/RepoPreviewCard";
 import LinkPreviewCard from "../Board/LinkPreviewCard";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { urlForPost } from "@src/utils/urlForPost";
 import { createRootComment } from "@api/comments";
 
@@ -150,9 +150,13 @@ export default function PostDetail({ post }: { post: PostMeta }) {
       {/* 상단 바 */}
       <div className="flex items-center justify-between text-sm text-base-content/70">
         <div className="flex items-center gap-2">
-          <span className="font-medium text-base-content">
+          <Link
+            to={`/board/${post.boardSlug}`}
+            className="font-medium text-base-content hover:underline"
+            aria-label={`${BOARD_LABEL[post.boardName] ?? post.boardName} 목록으로 이동`}
+          >
             {BOARD_LABEL[post.boardName] ?? post.boardName}
-          </span>
+          </Link>
           <span>•</span>
           <span>{fmtDate(post.createdAt)}</span>
         </div>

--- a/src/constants/boardDisplay.ts
+++ b/src/constants/boardDisplay.ts
@@ -1,0 +1,10 @@
+import type { BoardSlug } from "./board";
+
+// 화면 표시용은 서비스에서 사용하는 내용과 맞춤
+export const BOARD_DISPLAY_NAME: Record<BoardSlug, string> = {
+  free: "자유 게시판",
+  jobs: "취업 게시판",
+  info: "정보 게시판",
+  survey: "설문 게시판",
+  github: "GitHub 게시판",
+};

--- a/src/pages/boards/PostDetailPage.tsx
+++ b/src/pages/boards/PostDetailPage.tsx
@@ -4,6 +4,7 @@ import { fetchPostDetail, type PostDetail as ApiPostDetail } from "@api/posts";
 import PostDetail from "@components/Post/PostDetail"; // 네가 준 컴포넌트
 import type { PostMeta } from "@src/types/post";
 import { fetchGithubExtra, fetchSurveyExtra } from "@src/api/posts.special";
+import { BOARD_DISPLAY_NAME } from "@constants/boardDisplay";
 
 const BOARD_ALIAS: Record<
   number,
@@ -64,13 +65,19 @@ export default function PostDetailPage() {
   const postMeta: PostMeta | null = useMemo(() => {
     if (!data) return null;
 
+    // 1) board id -> slug(alias)
+    const alias = BOARD_ALIAS[data.board] ?? "free";
+
+    // 2) slug -> 화면 표기용 이름
+    const boardTitle = BOARD_DISPLAY_NAME[alias] ?? "게시판";
+
     // PostDetail(API) -> PostMeta(UI) 매핑
     return {
       id: data.id,
       title: data.title,
       content: data.content, // HTML 그대로
       authorId: String(data.user ?? ""), // PostDetail.tsx가 string 기대
-      boardName: BOARD_ALIAS[data.board] ?? "free",
+      boardName: boardTitle,
       views: data.view_count ?? 0,
       commentsCount: Array.isArray(data.root_comments)
         ? data.root_comments.length

--- a/src/pages/boards/PostDetailPage.tsx
+++ b/src/pages/boards/PostDetailPage.tsx
@@ -78,6 +78,7 @@ export default function PostDetailPage() {
       content: data.content, // HTML 그대로
       authorId: String(data.user ?? ""), // PostDetail.tsx가 string 기대
       boardName: boardTitle,
+      boardSlug: alias,
       views: data.view_count ?? 0,
       commentsCount: Array.isArray(data.root_comments)
         ? data.root_comments.length

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,6 +1,7 @@
 export interface PostMeta {
   id: string;
   boardName: string; // 예: "OO 게시판"
+  boardSlug: "free" | "jobs" | "info" | "survey" | "github";
   title: string;
   content: string; // \n 포함 가능
   cohort?: string; // 예: "11기"


### PR DESCRIPTION
- 별도의 상수 파일(boardDisplay.ts) 추가하여 서비스에서 사용되는 게시판 제목과 상세 페이지 제목을 통일
- 상세 페이지의 게시판 제목 클릭 시 해당 게시판 페이지로 이동하도록 연결
<img width="366" height="173" alt="image" src="https://github.com/user-attachments/assets/a29c0582-ee77-458c-893f-319714548022" />

---

closes #191 
