### PR TITLE
[fix] 설문/깃헙 게시판에서 상세페이지로 넘어가는 경로 설정 (버셀 제한으로 인한 재시도)

### DIFF
--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -69,7 +69,7 @@ export default function GithubListPage() {
       <section className="w-full rounded-xl border border-base-content/30 p-3 pb-8 h-[calc(100vh-200px)] overflow-hidden">
         <GithubList
           items={items}
-          onItemClick={(id) => nav(urlForPost.postDetail("github", id))}
+          onItemClick={(id) => nav(`/posts/${id}`)}
           onRepoClick={onRepoClick}
           topBar={{
             boardName: "GitHub 게시판",

--- a/src/pages/boards/SurveyListPage.tsx
+++ b/src/pages/boards/SurveyListPage.tsx
@@ -76,7 +76,7 @@ export default function SurveyListPage() {
       <section className="w-full rounded-xl border border-base-content/30 p-3 pb-8 h-[calc(100vh-200px)] overflow-hidden">
         <SurveyList
           items={sortedItems}
-          onItemClick={(id) => nav(urlForPost.postDetail("survey", id))}
+          onItemClick={(id) => nav(`/posts/${id}`)}
           topBar={{
             boardName: "설문 게시판",
             onOpenTag: () => {}, // TODO[UI→API-TAGS]: 태그 필터를 훅/서버에 연결


### PR DESCRIPTION
버셀 배포 제한으로 인해 이슈 없는데도 문제가 생겨서 다시 PR 올립니다.
제한 풀리면 트리거 커밋 푸시해서 확인하겠습니다.