### PR TITLE
[fix] 게시글 작성 페이지 양옆 잘림 문제 해결

### DIFF
--- a/src/components/Board/WritePostPage.tsx
+++ b/src/components/Board/WritePostPage.tsx
@@ -44,7 +44,7 @@ const WritePostPage = () => {
   };
 
   return (
-    <div className="flex flex-col h-full gap-2 text-black">
+    <div className="flex flex-col w-full h-full gap-2 text-black">
       {/* 1. 게시판 선택 */}
       <div>
         <select


### PR DESCRIPTION
더이상 게시글 작성 페이지가 잘려있지 않습니다.

<img width="1246" height="1247" alt="image" src="https://github.com/user-attachments/assets/615e2165-309c-4e5f-8849-489e0b88c3b6" />
