### PR TITLE
[feat] 태그 필터 로직 구현, API 연결

### DIFF
--- a/src/api/posts.ts
+++ b/src/api/posts.ts
@@ -50,6 +50,8 @@ export async function fetchPosts(params?: {
   ordering?: "-created_at" | "created_at" | "-view_count" | "view_count";
   page?: number; // DRF는 1-base, 0은 절대 보내지 않기
   page_size?: number;
+  user_tag_class?: "FE" | "BE";
+  user_tag_number?: number;
 }) {
   const query = new URLSearchParams();
 
@@ -58,6 +60,12 @@ export async function fetchPosts(params?: {
   if (params?.ordering) query.set("ordering", params.ordering);
   if (params?.page) query.set("page", String(params.page));
   if (params?.page_size) query.set("page_size", String(params.page_size));
+  if (params?.user_tag_class) {
+    query.set("user_tag_class", params.user_tag_class);
+  }
+  if (typeof params?.user_tag_number === "number") {
+    query.set("user_tag_number", String(params.user_tag_number));
+  }
 
   try {
     const { data } = await api.get<
@@ -66,9 +74,13 @@ export async function fetchPosts(params?: {
     return Array.isArray(data) ? data : (data?.results ?? []);
   } catch (e: unknown) {
     const err = e as AxiosError;
-    if (err.response?.status === 404) {
+    if (err.response?.status === 404 || err.response?.status === 500) {
       if (import.meta.env.DEV) {
-        console.info("[useInfiniteQuery] 더 불러올 데이터 없음 (404 수신)");
+        console.info(
+          "[useInfiniteQuery] 불러올 데이터 없음 (",
+          err.response?.status,
+          " 수신)"
+        );
       }
       return [];
     }

--- a/src/components/Board/common/tagfilter/TagFilterPopover.tsx
+++ b/src/components/Board/common/tagfilter/TagFilterPopover.tsx
@@ -17,7 +17,7 @@ type Props = {
   onChangePosition: (v: PositionValue) => void;
   onChangeCohort: (v: number) => void;
   onReset?: () => void; // (옵션) 외부 초기화 버튼이 따로 있을 때만 사용
-  onApply?: () => void; // (옵션) 적용 알림만 필요하면 사용
+  onApply?: (next: { pos: PositionValue; cohort: number } | null) => void;
   onRequestClose: () => void; // 닫힘
   // (선택) 내부 초기화 기본값 — 없으면 back/11로 처리
   defaultPosition?: PositionValue;
@@ -130,20 +130,27 @@ export default function TagFilterPopover({
     };
   }, [open, onRequestClose, anchorRef]);
 
-  // 적용 시에만 상위 콜백 호출
   const handleApply = useCallback(() => {
+    // 부모로 최신 draft 값 전달 → 적용
+    onApply?.({ pos: draftPosition, cohort: draftCohort });
+    // 내부 표시 상태도 동기화 (선택)
     onChangePosition(draftPosition);
     onChangeCohort(draftCohort);
-    onApply?.();
     onRequestClose();
   }, [
     draftPosition,
     draftCohort,
+    onApply,
     onChangePosition,
     onChangeCohort,
-    onApply,
     onRequestClose,
   ]);
+
+  const handleClear = useCallback(() => {
+    // 전체 보기(필터 미적용)
+    onApply?.(null);
+    onRequestClose();
+  }, [onApply, onRequestClose]);
 
   // 초기화는 draft만 리셋 (외부 상태는 건들지 않음)
   const handleReset = useCallback(() => {
@@ -186,6 +193,13 @@ export default function TagFilterPopover({
         </div>
 
         <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleClear}
+            className="btn btn-ghost btn-sm mr-auto"
+          >
+            필터 해제
+          </button>
           <button
             type="button"
             onClick={handleReset}

--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -5,11 +5,11 @@ import EmptyState, {
 import PostRow, { type FreeBoardItem, FREE_LIST_GRID } from "./PostRow";
 // import PostCard from "./PostCard"; // 반응형 임시 삭제, UI 통일감 목적
 import { LastLoadedBar, BoardTopBar } from "../common";
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import SortRadioPopover from "@components/Board/common/sort/SortRadioPopover";
 import TagFilterPopover from "@components/Board/common/tagfilter/TagFilterPopover";
 import type { SortValue } from "@src/types/sort";
-import type { PositionValue } from "@components/Board/common/tagfilter/PositionRadio";
+import type { PositionValue } from "@src/types/tag";
 import { ERROR_MESSAGES, LIST_MESSAGES, LOADING_MESSAGES } from "@constants/ui";
 
 export type PostListProps = {
@@ -44,6 +44,10 @@ export type PostListProps = {
 
   sortValue?: SortValue;
   onChangeSort?: (v: SortValue) => void;
+
+  tagValue?: { pos: PositionValue; cohort: number };
+  tagApplied?: boolean; // 뱃지는 이거로만 판단
+  onApplyTag?: (next: { pos: PositionValue; cohort: number } | null) => void;
 };
 
 export default function PostList({
@@ -64,6 +68,9 @@ export default function PostList({
   renderAuthorLabel,
   sortValue,
   onChangeSort,
+  tagValue,
+  tagApplied,
+  onApplyTag,
 }: PostListProps) {
   // ------ 정렬(UI) ------
   const sortBtnRef = useRef<HTMLButtonElement>(null);
@@ -81,7 +88,15 @@ export default function PostList({
   const [openTag, setOpenTag] = useState(false);
   const [position, setPosition] = useState<PositionValue>("back");
   const [cohort, setCohort] = useState<number>(11);
-  const tagActive = position !== "back" || cohort !== 11;
+  const tagActive = !!tagApplied;
+
+  // 부모에서 내려준 현재 선택값(tagValue)과 내부 상태 동기화
+  useEffect(() => {
+    if (!tagValue) return;
+    // 동일 값일 때는 setState 스킵 (불필요한 리렌더 방지)
+    if (position !== tagValue.pos) setPosition(tagValue.pos);
+    if (cohort !== tagValue.cohort) setCohort(tagValue.cohort);
+  }, [tagValue?.pos, tagValue?.cohort]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const isEmpty = items.length === 0;
 
@@ -221,9 +236,9 @@ export default function PostList({
           setPosition("back");
           setCohort(11);
         }}
-        onApply={() => {
-          // UI 전용: 여기서는 fetch 안 함
-          // TODO: 실제 연동 시 상위(PostListPage)에서 상태를 들고 있다가 refetch + lastLoadedAt 갱신하면 됨
+        onApply={(next) => {
+          onApplyTag?.(next); // {pos, cohort} | null
+          setOpenTag(false);
         }}
         onRequestClose={() => setOpenTag(false)}
       />

--- a/src/components/Board/github/GithubList.tsx
+++ b/src/components/Board/github/GithubList.tsx
@@ -1,11 +1,11 @@
 import ScrollSentinel from "@components/commons/InfiniteScroll/ScrollSentinel";
 import { LastLoadedBar, BoardTopBar } from "@components/Board/common";
 import GithubCard, { type GithubCardProps } from "./GithubCard";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import SortRadioPopover from "@components/Board/common/sort/SortRadioPopover";
 import type { SortValue } from "@src/types/sort";
 import TagFilterPopover from "@components/Board/common/tagfilter/TagFilterPopover";
-import type { PositionValue } from "@components/Board/common/tagfilter/PositionRadio";
+import type { PositionValue } from "@src/types/tag";
 import { LIST_MESSAGES } from "@src/constants/ui";
 
 export type GithubListItem = GithubCardProps;
@@ -40,6 +40,10 @@ export type GithubListProps = {
 
   sortValue?: SortValue;
   onChangeSort?: (v: SortValue) => void;
+
+  tagValue?: { pos: PositionValue; cohort: number };
+  tagApplied?: boolean;
+  onApplyTag?: (next: { pos: PositionValue; cohort: number } | null) => void;
 };
 
 export default function GithubList({
@@ -60,6 +64,9 @@ export default function GithubList({
   scrollRootRef,
   sortValue,
   onChangeSort,
+  tagValue,
+  tagApplied,
+  onApplyTag,
 }: GithubListProps) {
   const isEmpty = items.length === 0;
 
@@ -78,7 +85,13 @@ export default function GithubList({
   const [openTag, setOpenTag] = useState(false);
   const [position, setPosition] = useState<PositionValue>("back");
   const [cohort, setCohort] = useState<number>(11);
-  const tagActive = position !== "back" || cohort !== 11;
+  const tagActive = !!tagApplied;
+
+  useEffect(() => {
+    if (!tagValue) return;
+    if (position !== tagValue.pos) setPosition(tagValue.pos);
+    if (cohort !== tagValue.cohort) setCohort(tagValue.cohort);
+  }, [tagValue?.pos, tagValue?.cohort]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <section className={`flex h-full flex-col ${className ?? ""}`}>
@@ -181,8 +194,9 @@ export default function GithubList({
           setPosition("back");
           setCohort(11);
         }}
-        onApply={() => {
-          // UI 전용: 실제 refetch/lastLoadedAt 갱신은 상위로 승격할 때 연결
+        onApply={(next) => {
+          onApplyTag?.(next);
+          setOpenTag(false);
         }}
         onRequestClose={() => setOpenTag(false)}
       />

--- a/src/components/Board/survey/SurveyList.tsx
+++ b/src/components/Board/survey/SurveyList.tsx
@@ -2,11 +2,11 @@ import ScrollSentinel from "@components/commons/InfiniteScroll/ScrollSentinel";
 import SurveyCard, { type SurveyCardProps } from "./SurveyCard";
 import EmptyState, { type EmptyStateProps } from "../common/EmptyState";
 import { LastLoadedBar, BoardTopBar } from "../common";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import SortRadioPopover from "@components/Board/common/sort/SortRadioPopover";
 import type { SortValue } from "@src/types/sort";
 import TagFilterPopover from "@components/Board/common/tagfilter/TagFilterPopover";
-import type { PositionValue } from "@components/Board/common/tagfilter/PositionRadio";
+import type { PositionValue } from "@src/types/tag";
 import { LIST_MESSAGES } from "@src/constants/ui";
 
 export type SurveyListProps = {
@@ -39,6 +39,10 @@ export type SurveyListProps = {
 
   sortValue?: SortValue;
   onChangeSort?: (v: SortValue) => void;
+
+  tagValue?: { pos: PositionValue; cohort: number };
+  tagApplied?: boolean;
+  onApplyTag?: (next: { pos: PositionValue; cohort: number } | null) => void;
 };
 
 export default function SurveyList({
@@ -58,6 +62,9 @@ export default function SurveyList({
   scrollRootRef,
   sortValue,
   onChangeSort,
+  tagValue,
+  tagApplied,
+  onApplyTag,
 }: SurveyListProps) {
   const isEmpty = items.length === 0;
 
@@ -76,7 +83,13 @@ export default function SurveyList({
   const [openTag, setOpenTag] = useState(false);
   const [position, setPosition] = useState<PositionValue>("back");
   const [cohort, setCohort] = useState<number>(11);
-  const tagActive = position !== "back" || cohort !== 11;
+  const tagActive = !!tagApplied;
+
+  useEffect(() => {
+    if (!tagValue) return;
+    if (position !== tagValue.pos) setPosition(tagValue.pos);
+    if (cohort !== tagValue.cohort) setCohort(tagValue.cohort);
+  }, [tagValue?.pos, tagValue?.cohort]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <section className={`flex h-full flex-col ${className ?? ""}`}>
@@ -173,9 +186,9 @@ export default function SurveyList({
           setPosition("back");
           setCohort(11);
         }}
-        onApply={() => {
-          // UI 전용: 실제 fetch/refetch는 상위 승격 시 연결
-          // (PostList에서 쓰던 패턴 그대로)
+        onApply={(next) => {
+          onApplyTag?.(next);
+          setOpenTag(false);
         }}
         onRequestClose={() => setOpenTag(false)}
       />

--- a/src/features/tags/adapters.ts
+++ b/src/features/tags/adapters.ts
@@ -37,16 +37,3 @@ export function adaptUserTag(raw?: RawUserTag | null): Tag[] {
 
   return tags;
 }
-
-/** 작성자 라벨(예: "11기 · 프론트") */
-export function tagsToAuthorLabel(tags: Tag[]): string {
-  const cohort = tags.find((t) => t.category === "cohort")?.label;
-  const pos = tags.find((t) => t.category === "position")?.label;
-  if (cohort && pos) return `${cohort} · ${pos}`;
-  return cohort ?? pos ?? "";
-}
-
-/** RawUserTag 바로 → 작성자 라벨 */
-export function rawUserTagToAuthorLabel(raw?: RawUserTag | null): string {
-  return tagsToAuthorLabel(adaptUserTag(raw));
-}

--- a/src/features/tags/adapters.ts
+++ b/src/features/tags/adapters.ts
@@ -1,13 +1,24 @@
 import type { RawUserTag, Tag } from "@src/types/tag";
 
-/** 서버의 1개 user 태그 객체 → 프론트용 Tag[] (cohort/position 2개로 분리) */
+/** 서버 RawUserTag 타입가드 (안전한 분기용) */
+export function isRawUserTag(u: unknown): u is RawUserTag {
+  return (
+    typeof u === "object" &&
+    u !== null &&
+    typeof (u as { id?: unknown }).id === "number" &&
+    (u as { tag_class?: unknown }).tag_class !== undefined &&
+    typeof (u as { tag_number?: unknown }).tag_number === "number"
+  );
+}
+
+/** 서버의 user 태그 1개 → 프론트 Tag[] (cohort/position 2개로 분리) */
 export function adaptUserTag(raw?: RawUserTag | null): Tag[] {
   if (!raw) return [];
 
   const tags: Tag[] = [];
 
   // cohort (기수)
-  if (raw.tag_number != null) {
+  if (typeof raw.tag_number === "number") {
     tags.push({
       id: `${raw.id}-cohort`,
       category: "cohort",
@@ -16,14 +27,26 @@ export function adaptUserTag(raw?: RawUserTag | null): Tag[] {
   }
 
   // position (FE/BE)
-  if (raw.tag_class) {
-    const label = raw.tag_class === "FE" ? "프론트" : "백엔드";
+  if (raw.tag_class === "FE" || raw.tag_class === "BE") {
     tags.push({
       id: `${raw.id}-pos`,
       category: "position",
-      label,
+      label: raw.tag_class === "FE" ? "프론트" : "백엔드",
     });
   }
 
   return tags;
+}
+
+/** 작성자 라벨(예: "11기 · 프론트") */
+export function tagsToAuthorLabel(tags: Tag[]): string {
+  const cohort = tags.find((t) => t.category === "cohort")?.label;
+  const pos = tags.find((t) => t.category === "position")?.label;
+  if (cohort && pos) return `${cohort} · ${pos}`;
+  return cohort ?? pos ?? "";
+}
+
+/** RawUserTag 바로 → 작성자 라벨 */
+export function rawUserTagToAuthorLabel(raw?: RawUserTag | null): string {
+  return tagsToAuthorLabel(adaptUserTag(raw));
 }

--- a/src/features/tags/adapters.ts
+++ b/src/features/tags/adapters.ts
@@ -1,4 +1,5 @@
 import type { RawUserTag, Tag } from "@src/types/tag";
+import { TAG_LABELS } from "@utils/tagRules";
 
 /** 서버 RawUserTag 타입가드 (안전한 분기용) */
 export function isRawUserTag(u: unknown): u is RawUserTag {
@@ -17,7 +18,6 @@ export function adaptUserTag(raw?: RawUserTag | null): Tag[] {
 
   const tags: Tag[] = [];
 
-  // cohort (기수)
   if (typeof raw.tag_number === "number") {
     tags.push({
       id: `${raw.id}-cohort`,
@@ -26,12 +26,11 @@ export function adaptUserTag(raw?: RawUserTag | null): Tag[] {
     });
   }
 
-  // position (FE/BE)
-  if (raw.tag_class === "FE" || raw.tag_class === "BE") {
+  if (raw.tag_class && TAG_LABELS[raw.tag_class]) {
     tags.push({
       id: `${raw.id}-pos`,
       category: "position",
-      label: raw.tag_class === "FE" ? "프론트" : "백엔드",
+      label: TAG_LABELS[raw.tag_class],
     });
   }
 

--- a/src/features/tags/queryMap.ts
+++ b/src/features/tags/queryMap.ts
@@ -1,0 +1,8 @@
+export type PositionValue = "front" | "back" | "startup" | "design";
+
+/** UI 포지션 → 서버 class */
+export function posToTagClass(pos?: PositionValue): "FE" | "BE" | undefined {
+  if (pos === "front") return "FE";
+  if (pos === "back") return "BE";
+  return undefined; // startup/design은 현재 태깅 대상 아님
+}

--- a/src/features/tags/queryMap.ts
+++ b/src/features/tags/queryMap.ts
@@ -1,4 +1,4 @@
-export type PositionValue = "front" | "back" | "startup" | "design";
+import type { PositionValue } from "@src/types/tag";
 
 /** UI 포지션 → 서버 class */
 export function posToTagClass(pos?: PositionValue): "FE" | "BE" | undefined {

--- a/src/hooks/useBoardPosts.ts
+++ b/src/hooks/useBoardPosts.ts
@@ -6,46 +6,61 @@ import type { BoardSlug } from "@src/constants/boards";
 import { LIST_SETTINGS } from "@src/constants/ui";
 import type { AxiosError } from "axios";
 import type { SortValue } from "@src/types/sort";
+import type { TagFilter } from "@src/types/tag";
+
+type UseBoardPostsOpts = {
+  pageSize?: number;
+  sort: SortValue;
+  search?: string;
+  tags?: TagFilter; // { tagClass?: "FE"|"BE"; cohort?: number }
+};
 
 type FetchParams = NonNullable<Parameters<typeof fetchPosts>[0]>;
 type Ordering = NonNullable<FetchParams["ordering"]>;
 
 // UI 정렬 → API ordering
-const SORT_TO_ORDERING: Record<SortValue, Ordering> = {
+const SORT_TO_ORDERING: Record<string, Ordering> = {
   latest: "-created_at",
   oldest: "created_at",
+  // 과거/현재 키 혼재 가능성 대비(둘 다 매핑)
+  most_viewed: "-view_count",
+  least_viewed: "view_count",
   mostViewed: "-view_count",
   leastViewed: "view_count",
 };
 
-export function useBoardPosts(
-  board: BoardSlug,
-  opts?: {
-    pageSize?: number;
-    sort?: SortValue;
-    search?: string;
-  }
-) {
+export function useBoardPosts(board: BoardSlug, opts?: UseBoardPostsOpts) {
   const pageSize = opts?.pageSize ?? LIST_SETTINGS.ITEMS_PER_PAGE;
-  const ordering: Ordering = opts?.sort
-    ? SORT_TO_ORDERING[opts.sort]
-    : "-created_at";
+  const sort: SortValue = opts?.sort ?? "latest";
+  const search = opts?.search?.trim() || undefined;
+  const tags = opts?.tags;
+
+  const ordering: Ordering = SORT_TO_ORDERING[sort] ?? "-created_at";
 
   return useInfiniteQuery<PostListItem[], unknown>({
     queryKey: [
       "board-posts",
       board,
-      { pageSize, ordering, search: opts?.search ?? "" },
+      {
+        pageSize,
+        ordering,
+        search,
+        tags, // { tagClass, cohort }
+      },
     ],
     initialPageParam: 1,
+
     queryFn: ({ pageParam }) =>
       fetchPosts({
         board,
         page: pageParam as number, // DRF 1-base
         page_size: pageSize,
         ordering,
-        search: opts?.search,
-      }),
+        search, // undefined면 쿼리에 안 붙음
+        user_tag_class: tags?.tagClass,
+        user_tag_number:
+          typeof tags?.cohort === "number" ? tags!.cohort : undefined,
+      } as FetchParams),
 
     // 마지막 페이지 길이가 pageSize보다 작으면 더 없음
     getNextPageParam: (lastPage, allPages) => {
@@ -62,7 +77,6 @@ export function useBoardPosts(
 
     staleTime: 0,
     gcTime: 5 * 60 * 1000,
-    // 필요하면 포커스 리패치 끄기:
     // refetchOnWindowFocus: false,
   });
 }

--- a/src/hooks/useGithubPosts.ts
+++ b/src/hooks/useGithubPosts.ts
@@ -1,9 +1,13 @@
-import React from "react";
+// src/hooks/useGithubPosts.ts
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { GithubListItem } from "@components/Board/github/GithubList";
-import type { PostListItem } from "@api/posts";
-import { fetchGithubLinkById, fetchGithubListPage } from "@api/github";
 import { mapToGithubListItem } from "@src/features/posts/list/githubAdapter";
 import AssignedTagList from "@components/tags/AssignedTagList";
 import { adaptUserTag } from "@src/features/tags/adapters";
@@ -11,8 +15,11 @@ import type { RawUserTag } from "@api/tags";
 import { LIST_SETTINGS } from "@src/constants/ui";
 import type { AxiosError } from "axios";
 import type { SortValue } from "@src/types/sort";
+import { fetchPosts, type PostListItem } from "@api/posts";
+import { fetchGithubLinkById } from "@api/github";
+import type { TagFilter } from "@src/types/tag";
 
-// NOTE: 키 표시에만 사용 (API 파라미터는 github.ts에서 board id 사용)
+// NOTE: 키 표시에만 사용 (API 파라미터는 posts.ts에서 board slug → id 변환)
 const GITHUB_BOARD_SLUG = "github" as const;
 
 // UI SortValue → API ordering
@@ -34,10 +41,12 @@ export type UseGithubPostsOptions = {
   sort?: SortValue;
   search?: string;
   tagIds?: number[];
+  tags?: TagFilter;
 };
 
 type GithubPostsPage = { items: PostListItem[]; hasNext: boolean };
 
+// 페이지 단위 fetch (posts API 사용: 태그/정렬/검색 타입 안전)
 async function fetchGithubPage(
   page: number,
   opt?: UseGithubPostsOptions
@@ -45,14 +54,23 @@ async function fetchGithubPage(
   type SortKey = keyof typeof SORT_TO_ORDERING;
   const sortKey: SortKey = (opt?.sort ?? "latest") as SortKey;
   const ordering = SORT_TO_ORDERING[sortKey] ?? "-created_at";
+  const pageSize = opt?.pageSize ?? LIST_SETTINGS.ITEMS_PER_PAGE;
 
-  return fetchGithubListPage({
+  const list = await fetchPosts({
+    board: "github",
     page,
-    page_size: opt?.pageSize ?? LIST_SETTINGS.ITEMS_PER_PAGE,
+    page_size: pageSize,
     ordering,
-    // search: opt?.search,
-    // tags: opt?.tagIds,
+    search: opt?.search,
+    user_tag_class: opt?.tags?.tagClass,
+    user_tag_number:
+      typeof opt?.tags?.cohort === "number" ? opt!.tags!.cohort : undefined,
   });
+
+  return {
+    items: list,
+    hasNext: list.length >= pageSize,
+  };
 }
 
 export function useGithubPosts(opt?: UseGithubPostsOptions) {
@@ -60,6 +78,9 @@ export function useGithubPosts(opt?: UseGithubPostsOptions) {
   type SortKey = keyof typeof SORT_TO_ORDERING;
   const sortKey: SortKey = (opt?.sort ?? "latest") as SortKey;
   const ordering = SORT_TO_ORDERING[sortKey] ?? "-created_at";
+  const search = opt?.search ?? "";
+  const tagIds = opt?.tagIds ?? [];
+  const tags = opt?.tags;
 
   return useInfiniteQuery<GithubPostsPage, unknown>({
     // 옵션 포함해서 캐시 분리
@@ -69,8 +90,9 @@ export function useGithubPosts(opt?: UseGithubPostsOptions) {
         board: GITHUB_BOARD_SLUG,
         pageSize,
         ordering,
-        search: opt?.search ?? "",
-        tags: opt?.tagIds ?? [],
+        search,
+        tagIds,
+        tags,
       },
     ] as const,
 

--- a/src/hooks/useSurveys.ts
+++ b/src/hooks/useSurveys.ts
@@ -1,6 +1,7 @@
+// src/hooks/useSurveys.ts
 import React from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { fetchPosts } from "@api/posts";
+import { fetchPosts, type PostListItem } from "@api/posts";
 import type { SurveyCardProps } from "@components/Board/survey/SurveyCard";
 import {
   mapToSurveyCard,
@@ -10,49 +11,59 @@ import { fetchSurveyExtra } from "@src/api/posts.special";
 import { LIST_SETTINGS } from "@src/constants/ui";
 import type { AxiosError } from "axios";
 import AssignedTagList from "@components/tags/AssignedTagList";
-import { adaptUserTag } from "@src/features/tags/adapters";
-import type { RawUserTag } from "@api/tags";
-import type { SortValue } from "@src/types/sort";
+import { adaptUserTag, isRawUserTag } from "@src/features/tags/adapters";
+import type { TagFilter } from "@src/types/tag";
 
-const SORT_TO_ORDERING: Record<
-  SortValue,
-  "-created_at" | "created_at" | "-view_count" | "view_count"
-> = {
-  latest: "-created_at",
-  oldest: "created_at",
-  mostViewed: "-view_count",
-  leastViewed: "view_count",
+export type UseSurveysOpts = {
+  pageSize?: number;
+  tags?: TagFilter; // { tagClass?: "FE"|"BE"; cohort?: number }
+};
+
+// 정렬용 메타를 포함한 카드 타입 (추가 필드: createdAtMs, responseCount)
+export type SortableSurveyCard = SurveyCardProps & {
+  createdAtMs: number;
+  responseCount: number;
 };
 
 export const SURVEYS_KEY = ["surveys"] as const;
-const PAGE_SIZE = LIST_SETTINGS.ITEMS_PER_PAGE;
+const DEFAULT_PAGE_SIZE = LIST_SETTINGS.ITEMS_PER_PAGE;
 
-type Page = { items: SurveyCardProps[]; hasMore: boolean; page: number };
+type Page = { items: SortableSurveyCard[]; hasMore: boolean; page: number };
 
-/** 작성자 태그 원본 타입 가드 */
-const isRawUserTag = (u: unknown): u is RawUserTag =>
-  typeof u === "object" &&
-  u !== null &&
-  typeof (u as { id?: unknown }).id === "number" &&
-  (u as { tag_class?: unknown }).tag_class !== undefined &&
-  typeof (u as { tag_number?: unknown }).tag_number === "number";
+// 안전하게 숫자 속성 뽑아오는 유틸
+function pickNumber(obj: unknown, keys: string[], fallback: number): number {
+  for (const k of keys) {
+    if (
+      obj &&
+      typeof obj === "object" &&
+      k in (obj as Record<string, unknown>)
+    ) {
+      const v = (obj as Record<string, unknown>)[k];
+      const n = typeof v === "number" ? v : Number(v);
+      if (!Number.isNaN(n)) return n;
+    }
+  }
+  return fallback;
+}
 
-export function useSurveys(sort: SortValue = "latest") {
+export function useSurveys(opts: UseSurveysOpts = {}) {
+  const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
+  const tags = opts.tags;
+
   return useInfiniteQuery<Page, unknown>({
-    // 페이지 크기 등이 바뀌면 캐시 키 분리되도록 포함
-    queryKey: [
-      ...SURVEYS_KEY,
-      { pageSize: PAGE_SIZE, ordering: SORT_TO_ORDERING[sort] },
-    ],
+    queryKey: [...SURVEYS_KEY, { pageSize, tags }],
     initialPageParam: 1,
 
     queryFn: async ({ pageParam }) => {
-      // 1) 기본 목록
-      const list = await fetchPosts({
+      // 1) 목록 호출 (최신순 고정)
+      const list: PostListItem[] = await fetchPosts({
         board: "survey",
-        ordering: SORT_TO_ORDERING[sort],
+        ordering: "-created_at",
         page: pageParam as number, // DRF 1-base
-        page_size: PAGE_SIZE,
+        page_size: pageSize,
+        user_tag_class: tags?.tagClass,
+        user_tag_number:
+          typeof tags?.cohort === "number" ? tags!.cohort : undefined,
       });
 
       // 2) 부가정보 병렬 요청 (빈 목록이면 생략)
@@ -66,50 +77,53 @@ export function useSurveys(sort: SortValue = "latest") {
                     const ex = await fetchSurveyExtra(p.id);
                     return [p.id, ex] as [number, SurveyExtra];
                   } catch {
-                    return [p.id, {}] as [number, SurveyExtra];
+                    return [p.id, {} as SurveyExtra] as [number, SurveyExtra];
                   }
                 })
               )
             );
 
-      // 3) UI 매핑
-      const items: SurveyCardProps[] = list.map((p) => {
-        const card = mapToSurveyCard(p, extrasMap.get(p.id));
+      // 3) UI 매핑 + 작성자 태그 배지 + 정렬 메타 필드 계산
+      const items: SortableSurveyCard[] = list.map((p) => {
+        const baseCard = mapToSurveyCard(p, extrasMap.get(p.id));
+
         const maybeUser = (p as unknown as { user?: unknown }).user;
         const rawUser = isRawUserTag(maybeUser) ? maybeUser : null;
         const authorTags = adaptUserTag(rawUser);
 
-        (card as any).createdAtMs = Date.parse((p as any).created_at ?? 0) || 0;
-        (card as any).responseCount = Number(
-          (p as any).response_count ??
-            (p as any).participants ??
-            (p as any).votes ??
-            (p as any).view_count ?? // 최종 폴백
-            0
+        const extra = extrasMap.get(p.id);
+        const createdAtMs = Date.parse(p.created_at ?? "") || 0;
+        const responseCount = pickNumber(
+          extra,
+          ["response_count", "participants", "votes"],
+          Number(p.view_count ?? 0)
         );
+
+        const withMeta: SortableSurveyCard = {
+          ...baseCard,
+          createdAtMs,
+          responseCount,
+        };
 
         return authorTags.length > 0
           ? {
-              ...card,
+              ...withMeta,
               tagSlot: React.createElement(AssignedTagList, {
                 tags: authorTags,
               }),
             }
-          : card;
+          : withMeta;
       });
 
       return {
         items,
-        // 마지막 페이지 길이가 PAGE_SIZE 미만이면 불러올 것 더 없음
-        hasMore: list.length >= PAGE_SIZE,
+        hasMore: list.length >= pageSize,
         page: pageParam as number,
       };
     },
 
-    // hasMore 기반 다음 페이지 계산
     getNextPageParam: (last) => (last.hasMore ? last.page + 1 : undefined),
 
-    // 404는 "끝" 신호로 보고 재시도/에러 전환 방지
     retry: (failureCount, err) => {
       const ae = err as AxiosError | undefined;
       if (ae?.response?.status === 404) return false;
@@ -118,6 +132,5 @@ export function useSurveys(sort: SortValue = "latest") {
 
     staleTime: 0,
     gcTime: 5 * 60 * 1000,
-    // 필요 시: refetchOnWindowFocus: false,
   });
 }

--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -6,6 +6,8 @@ import { formatYyyyMmDdHms } from "@utils/date";
 import { urlForPost } from "@src/utils/urlForPost";
 import { useGithubPosts, useGithubListWithLinks } from "@hooks/useGithubPosts";
 import type { SortValue } from "@src/types/sort";
+import type { PositionValue } from "@src/types/tag";
+import { posToTagClass } from "@utils/tagRules";
 
 export default function GithubListPage() {
   const nav = useNavigate();
@@ -15,7 +17,12 @@ export default function GithubListPage() {
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
 
   const [sort, setSort] = useState<SortValue>("latest");
-  const [tagIds] = useState<number[] | undefined>(undefined);
+  const [pos, setPos] = useState<PositionValue>("back");
+  const [cohort, setCohort] = useState<number>(11);
+  const [activeFilter, setActiveFilter] = useState<{
+    pos: PositionValue;
+    cohort: number;
+  } | null>(null);
   const [search] = useState<string | undefined>(undefined);
 
   const {
@@ -29,9 +36,13 @@ export default function GithubListPage() {
     refetch,
   } = useGithubPosts({
     sort,
-    tagIds, // TODO(tags): Tag UI onApply → setTagIds
+    tags: activeFilter
+      ? {
+          tagClass: posToTagClass(activeFilter.pos),
+          cohort: activeFilter.cohort,
+        }
+      : undefined,
     search, // TODO(search): Search onSubmit → setSearch
-    // pageSize: 10,           // 필요 시 교체
   });
 
   // 링크/OG까지 보강된 items + onRepoClick
@@ -73,8 +84,6 @@ export default function GithubListPage() {
           onRepoClick={onRepoClick}
           topBar={{
             boardName: "GitHub 게시판",
-            // TODO(tags): 태그 팝오버 → 선택값 setTagIds → 훅 옵션 반영
-            onOpenTag: () => {},
             onWrite: () => nav(urlForPost.postCreate("github")),
           }}
           lastLoadedAt={lastLoadedAt}
@@ -90,6 +99,19 @@ export default function GithubListPage() {
           sortValue={sort}
           onChangeSort={(v) => {
             setSort(v);
+            setLastLoadedAt(formatYyyyMmDdHms(new Date()));
+            rootEl?.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
+          }}
+          tagValue={{ pos, cohort }}
+          tagApplied={!!activeFilter}
+          onApplyTag={(next) => {
+            if (next) {
+              setPos(next.pos);
+              setCohort(next.cohort);
+              setActiveFilter(next); // 적용
+            } else {
+              setActiveFilter(null); // 전체보기(필터 해제)
+            }
             setLastLoadedAt(formatYyyyMmDdHms(new Date()));
             rootEl?.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
           }}

--- a/src/pages/boards/PostListPage.tsx
+++ b/src/pages/boards/PostListPage.tsx
@@ -8,8 +8,9 @@ import { formatYyyyMmDdHms } from "@utils/date";
 import { useBoardPosts } from "@hooks/useBoardPosts";
 import { LIST_SETTINGS, ERROR_MESSAGES } from "@constants/ui";
 import { tagsToAuthorLabel } from "@utils/tagsToAuthorLabel";
-import { adaptUserTag } from "@src/features/tags/adapters";
-import type { RawUserTag } from "@api/tags";
+import { adaptUserTag, isRawUserTag } from "@src/features/tags/adapters";
+import { posToTagClass } from "@utils/tagRules";
+import type { PositionValue } from "@src/types/tag";
 import type { SortValue } from "@src/types/sort";
 
 const BOARD_LABEL: Record<BoardSlug, string> = {
@@ -27,10 +28,19 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
   );
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
   const [sort, setSort] = useState<SortValue>("latest");
+  const [pos, setPos] = useState<PositionValue>("back");
+  const [cohort, setCohort] = useState<number>(11);
+  const [activeFilter, setActiveFilter] = useState<{
+    pos: PositionValue;
+    cohort: number;
+  } | null>(null);
 
   // 게시판 변경 시 필터/스크롤 초기화
   useEffect(() => {
     setSort("latest");
+    setPos("back");
+    setCohort(11);
+    setActiveFilter(null);
     setLastLoadedAt(formatYyyyMmDdHms(new Date()));
     setRootEl(null);
   }, [board]);
@@ -48,21 +58,20 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
     pageSize: LIST_SETTINGS.ITEMS_PER_PAGE,
     sort,
     // search,                // TODO(filter): 검색어 연결
-    // tags: [...],           // TODO(filter): 태그 필터 연결
+
+    // 필터 적용된 경우에만 태그 파라미터 전송 → 포지션 & 기수 AND
+    tags: activeFilter
+      ? {
+          tagClass: posToTagClass(activeFilter.pos),
+          cohort: activeFilter.cohort,
+        }
+      : undefined,
   });
 
   // pages(flat) → PostListItem[]
   const items = useMemo(() => (data?.pages ?? []).flat(), [data]);
 
   const uiItems = useMemo(() => items.map(mapToFreeItem), [items]);
-
-  // 작성자 태그 타입가드
-  const isRawUserTag = (u: unknown): u is RawUserTag =>
-    typeof u === "object" &&
-    u !== null &&
-    typeof (u as { id?: unknown }).id === "number" &&
-    (u as { tag_class?: unknown }).tag_class !== undefined &&
-    typeof (u as { tag_number?: unknown }).tag_number === "number";
 
   // 작성자 라벨 맵: postId → "11기 · 프론트" 등
   const authorLabelMap = useMemo(() => {
@@ -74,6 +83,7 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
     }
     return m;
   }, [items]);
+
   // 초기 로딩/Empty 깜빡임 방지
   const hasNoPages = uiItems.length === 0;
   const isInitialLoading = hasNoPages && isFetching;
@@ -125,6 +135,19 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
           sortValue={sort}
           onChangeSort={(v) => {
             setSort(v);
+            setLastLoadedAt(formatYyyyMmDdHms(new Date()));
+            rootEl?.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
+          }}
+          tagValue={{ pos, cohort }}
+          tagApplied={!!activeFilter}
+          onApplyTag={(next) => {
+            if (next) {
+              setPos(next.pos);
+              setCohort(next.cohort);
+              setActiveFilter(next); // 필터 적용
+            } else {
+              setActiveFilter(null); // 전체 보기
+            }
             setLastLoadedAt(formatYyyyMmDdHms(new Date()));
             rootEl?.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
           }}

--- a/src/pages/boards/SurveyListPage.tsx
+++ b/src/pages/boards/SurveyListPage.tsx
@@ -5,9 +5,11 @@ import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
 import { formatYyyyMmDdHms } from "@utils/date";
 import { useSurveys } from "@src/hooks/useSurveys";
 import { urlForPost } from "@src/utils/urlForPost";
-import type { SurveyCardProps } from "@components/Board/survey/SurveyCard";
 import type { SortValue } from "@src/types/sort";
 import sortClientSide from "@src/utils/sortClientSide";
+import type { PositionValue } from "@src/types/tag";
+import { posToTagClass } from "@utils/tagRules";
+import type { SortableSurveyCard } from "@src/hooks/useSurveys";
 
 export default function SurveyListPage() {
   const nav = useNavigate();
@@ -17,6 +19,12 @@ export default function SurveyListPage() {
   );
   const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
   const [sort, setSort] = useState<SortValue>("latest");
+  const [pos, setPos] = useState<PositionValue>("back");
+  const [cohort, setCohort] = useState<number>(11);
+  const [activeFilter, setActiveFilter] = useState<{
+    pos: PositionValue;
+    cohort: number;
+  } | null>(null);
 
   const {
     data,
@@ -27,21 +35,25 @@ export default function SurveyListPage() {
     isError,
     error,
     refetch,
-  } = useSurveys();
+  } = useSurveys({
+    tags: activeFilter
+      ? {
+          tagClass: posToTagClass(activeFilter.pos),
+          cohort: activeFilter.cohort,
+        }
+      : undefined,
+  });
 
-  // 훅이 이미 SurveyCardProps[]를 반환하므로 플랫만 하면 됨
-  const items: SurveyCardProps[] = useMemo(
+  // 플랫
+  const items: SortableSurveyCard[] = useMemo(
     () => data?.pages.flatMap((p) => p.items) ?? [],
     [data]
   );
 
   const sortedItems = useMemo(() => {
     return sortClientSide(items, sort, {
-      createdAt: (it: any) =>
-        Number(it.createdAtMs ?? 0) ||
-        (it.deadline ? Date.parse(it.deadline) : 0) ||
-        Number(it.id ?? 0),
-      viewCount: (it: any) => Number(it.responseCount ?? it.participants ?? 0),
+      createdAt: (it: SortableSurveyCard) => it.createdAtMs,
+      viewCount: (it: SortableSurveyCard) => it.responseCount,
     });
   }, [items, sort]);
 
@@ -79,7 +91,6 @@ export default function SurveyListPage() {
           onItemClick={(id) => nav(urlForPost.postDetail("survey", id))}
           topBar={{
             boardName: "설문 게시판",
-            onOpenTag: () => {}, // TODO[UI→API-TAGS]: 태그 필터를 훅/서버에 연결
             onWrite: () => nav(urlForPost.postCreate("survey")),
           }}
           lastLoadedAt={lastLoadedAt}
@@ -95,6 +106,19 @@ export default function SurveyListPage() {
           sortValue={sort}
           onChangeSort={(v) => {
             setSort(v);
+            setLastLoadedAt(formatYyyyMmDdHms(new Date()));
+            rootEl?.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
+          }}
+          tagValue={{ pos, cohort }}
+          tagApplied={!!activeFilter}
+          onApplyTag={(next) => {
+            if (next) {
+              setPos(next.pos);
+              setCohort(next.cohort);
+              setActiveFilter(next);
+            } else {
+              setActiveFilter(null);
+            }
             setLastLoadedAt(formatYyyyMmDdHms(new Date()));
             rootEl?.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });
           }}

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -12,3 +12,10 @@ export type RawUserTag = {
   tag_class: "FE" | "BE";
   tag_number: number; // 기수 (예: 11)
 };
+
+export type PositionValue = "front" | "back" | "startup" | "design";
+export type TagClass = "FE" | "BE";
+export type TagFilter = {
+  tagClass?: TagClass;
+  cohort?: number;
+};

--- a/src/utils/tagMap.ts
+++ b/src/utils/tagMap.ts
@@ -1,0 +1,6 @@
+export type Pos = "front" | "back" | "startup" | "design";
+export function posToClass(pos: Pos): "FE" | "BE" | undefined {
+  if (pos === "front") return "FE";
+  if (pos === "back") return "BE";
+  return undefined; // startup/design은 현재 무시
+}

--- a/src/utils/tagMap.ts
+++ b/src/utils/tagMap.ts
@@ -1,6 +1,0 @@
-export type Pos = "front" | "back" | "startup" | "design";
-export function posToClass(pos: Pos): "FE" | "BE" | undefined {
-  if (pos === "front") return "FE";
-  if (pos === "back") return "BE";
-  return undefined; // startup/design은 현재 무시
-}

--- a/src/utils/tagRules.ts
+++ b/src/utils/tagRules.ts
@@ -1,4 +1,4 @@
-import type { Tag } from "@src/types/tag";
+import type { PositionValue, Tag, TagClass } from "@src/types/tag";
 
 /** 정확히 기수, 포지션 1개씩인지 검증 */
 export function validateAssignedTags(tags: Tag[]) {
@@ -25,3 +25,16 @@ export function mapUserToTags(cohort: string, position: string): Tag[] {
     },
   ];
 }
+
+// UI 포지션 → 서버 class
+export function posToTagClass(pos?: PositionValue): TagClass | undefined {
+  if (pos === "front") return "FE";
+  if (pos === "back") return "BE";
+  return undefined;
+}
+
+// 서버 RawUserTag → 라벨 문자열 변환 보조
+export const TAG_LABELS: Record<TagClass, string> = {
+  FE: "프론트",
+  BE: "백엔드",
+};


### PR DESCRIPTION
태그 필터 API 연결,
모든 게시글 페이지에 적용했습니다.

아래 테스트는 로컬 도커로 진행하였고
자유 게시판 외의 다른 게시판에서도 정상 작동되는 것 확인했습니다.

창업, 디자인은 아예 쿼리 파라미터 안 보내고 있어서
프론트엔드와 백엔드만 테스트 부탁드립니다.

### 미적용 상태: 전체 보기 (적용 버튼 눌러야만 태그 필터 적용됨)
<img width="868" height="366" alt="image" src="https://github.com/user-attachments/assets/eb5de7b7-5402-41c4-a372-d8c63786811b" />

### 태그 필터 활성화 (백엔드 && 11기)
<img width="1020" height="476" alt="image" src="https://github.com/user-attachments/assets/8863237d-f685-491f-90b0-32fb720097f8" />

### 태그 필터 활성화 (프론트엔드 && 11기)
<img width="1059" height="463" alt="image" src="https://github.com/user-attachments/assets/7b5fb3a4-819f-4b89-afa2-fb0f179cf722" />

### 태그 필터 활성화 (백엔드 && 3기)
<img width="996" height="454" alt="image" src="https://github.com/user-attachments/assets/564ed06a-904e-4344-a2b8-f0bfb72b27f2" />


---

closes #127 