### PR TITLE
[feat] 맨 위로 가기 버튼 UI 컴포넌트 구현 및 적용

### DIFF
--- a/src/components/Board/free/PostList.tsx
+++ b/src/components/Board/free/PostList.tsx
@@ -11,6 +11,7 @@ import TagFilterPopover from "@components/Board/common/tagfilter/TagFilterPopove
 import type { SortValue } from "@src/types/sort";
 import type { PositionValue } from "@src/types/tag";
 import { ERROR_MESSAGES, LIST_MESSAGES, LOADING_MESSAGES } from "@constants/ui";
+import { useScrollRoot } from "@components/commons/ScrollToTop/useScrollRoot";
 
 export type PostListProps = {
   items: FreeBoardItem[];
@@ -72,6 +73,13 @@ export default function PostList({
   tagApplied,
   onApplyTag,
 }: PostListProps) {
+  const { setRoot } = useScrollRoot();
+
+  const attachRef = (el: HTMLDivElement | null) => {
+    scrollRootRef?.(el);
+    setRoot(el);
+  };
+
   // ------ 정렬(UI) ------
   const sortBtnRef = useRef<HTMLButtonElement>(null);
   const [openSort, setOpenSort] = useState(false);
@@ -126,8 +134,8 @@ export default function PostList({
 
       {/* 본문 스크롤 컨테이너 */}
       <div
-        ref={scrollRootRef}
-        className="w-full px-3 flex-1 min-h-0 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]"
+        ref={attachRef}
+        className="w-full px-3 flex-1 min-h-0 h-full overflow-y-auto overscroll-contain [scrollbar-gutter:stable]"
       >
         {isError && (
           <div className="w-full py-10 text-center text-sm text-red-500">

--- a/src/components/commons/ScrollToTop/EnsureDefaultScrollRoot.tsx
+++ b/src/components/commons/ScrollToTop/EnsureDefaultScrollRoot.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useScrollRoot } from "./useScrollRoot";
+
+/** 맨 위로 가기 기본 루트 보장 헬퍼 */
+export default function EnsureDefaultScrollRoot({
+  elRef,
+}: {
+  elRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const { root, setRoot } = useScrollRoot();
+  useEffect(() => {
+    if (!root && elRef.current) setRoot(elRef.current);
+  }, [root, setRoot, elRef]);
+  return null;
+}

--- a/src/components/commons/ScrollToTop/LockOutletScrollWhenChildRoot.tsx
+++ b/src/components/commons/ScrollToTop/LockOutletScrollWhenChildRoot.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useScrollRoot } from "./useScrollRoot";
+
+/** Outlet 스크롤 잠금/해제 헬퍼(내부 스크롤 루트가 활성일 때 바깥 스크롤 방지) */
+export default function LockOutletScrollWhenChildRoot({
+  elRef,
+}: {
+  elRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const { root } = useScrollRoot();
+  useEffect(() => {
+    const el = elRef.current;
+    if (!el) return;
+    const shouldLock = root && el !== root;
+    const prev = el.style.overflowY;
+    el.style.overflowY = shouldLock ? "hidden" : "auto";
+    return () => {
+      el.style.overflowY = prev || "auto";
+    };
+  }, [root, elRef]);
+  return null;
+}

--- a/src/components/commons/ScrollToTop/OutletWithScrollToTop.tsx
+++ b/src/components/commons/ScrollToTop/OutletWithScrollToTop.tsx
@@ -1,0 +1,20 @@
+import { Outlet } from "react-router-dom";
+import ScrollToTopButton from "./ScrollToTopButton";
+import { useScrollRoot } from "./useScrollRoot";
+
+/** Outlet에 맨 위로 가기 버튼 붙이는 기능으로, root는 해당 페이지가 등록한 내부 스크롤 엘리먼트 */
+export default function OutletWithScrollToTop() {
+  const { root } = useScrollRoot();
+  return (
+    <div className="relative w-full">
+      <Outlet />
+      <div className="sticky bottom-6 w-full pointer-events-none z-[200]">
+        <div className="flex justify-end">
+          <div className="pointer-events-auto translate-x-2">
+            <ScrollToTopButton position="inline" root={root} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/commons/ScrollToTop/ScrollRootProvider.tsx
+++ b/src/components/commons/ScrollToTop/ScrollRootProvider.tsx
@@ -1,0 +1,16 @@
+import { useCallback, useState, type ReactNode } from "react";
+import { ScrollRootContext, type ScrollRoot } from "./scroll-root-store";
+
+export default function ScrollRootProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [root, setRootState] = useState<ScrollRoot>(null);
+  const setRoot = useCallback((el: ScrollRoot) => setRootState(el), []);
+  return (
+    <ScrollRootContext.Provider value={{ root, setRoot }}>
+      {children}
+    </ScrollRootContext.Provider>
+  );
+}

--- a/src/components/commons/ScrollToTop/ScrollToTopButton.tsx
+++ b/src/components/commons/ScrollToTop/ScrollToTopButton.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import clsx from "clsx";
+import { useThemeIcon } from "@src/hooks/useThemeIcon";
+
+import arrowUpDark from "@assets/icons/icon-arrow-upward-dark.svg";
+import arrowUpLight from "@assets/icons/icon-arrow-upward-light.svg";
+
+type Props = {
+  /** 스크롤 기준이 되는 엘리먼트 (없으면 window 사용) */
+  root?: HTMLElement | null;
+  /** 버튼 표시 임계치(px) */
+  threshold?: number;
+  /** 오른쪽/아래 여백 커스텀 하고 싶으면 className으로 조절 */
+  className?: string;
+};
+
+export default function ScrollToTopButton({
+  root,
+  threshold = 300,
+  className,
+}: Props) {
+  const themeIcon = useThemeIcon(); // "oz_dark" | "oz_light"
+  const [visible, setVisible] = useState(false);
+
+  const iconSrc = useMemo(
+    () => (themeIcon === "oz_dark" ? arrowUpDark : arrowUpLight),
+    [themeIcon]
+  );
+
+  const tickingRef = useRef(false);
+  const targetRef = useRef<HTMLElement | (Window & typeof globalThis) | null>(
+    null
+  );
+  const getScrollTop = useCallback(() => {
+    if (root) return root.scrollTop ?? 0;
+    return window.scrollY ?? window.pageYOffset ?? 0;
+  }, [root]);
+
+  const onScroll = useCallback(() => {
+    if (tickingRef.current) return;
+    tickingRef.current = true;
+    requestAnimationFrame(() => {
+      tickingRef.current = false;
+      const y = getScrollTop();
+      setVisible(y > threshold);
+    });
+  }, [getScrollTop, threshold]);
+
+  useEffect(() => {
+    const t = (root as HTMLElement) ?? window;
+    targetRef.current = t;
+    // 초기 상태 동기화
+    setVisible(getScrollTop() > threshold);
+
+    t.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      t.removeEventListener("scroll", onScroll as EventListener);
+      targetRef.current = null;
+    };
+  }, [root, threshold, onScroll, getScrollTop]);
+
+  const handleClick = useCallback(() => {
+    if (root) {
+      root.scrollTo({ top: 0, behavior: "smooth" });
+    } else {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, [root]);
+
+  return (
+    <button
+      type="button"
+      aria-label="맨 위로 가기"
+      onClick={handleClick}
+      className={clsx(
+        "fixed z-50 right-6 bottom-6 rounded-full shadow-xl border",
+        "bg-base-100 border-base-content/20 hover:border-base-content/40",
+        "transition-opacity duration-300 ease-out",
+        "focus:outline-none focus:ring-2 focus:ring-primary/50",
+        "p-3",
+        // 보이기/숨기기
+        visible ? "opacity-100" : "opacity-0 pointer-events-none",
+        className
+      )}
+    >
+      <img
+        src={iconSrc}
+        alt="맨 위로"
+        className="w-6 h-6 md:w-7 md:h-7 select-none"
+        draggable={false}
+      />
+    </button>
+  );
+}

--- a/src/components/commons/ScrollToTop/ScrollToTopButton.tsx
+++ b/src/components/commons/ScrollToTop/ScrollToTopButton.tsx
@@ -12,12 +12,15 @@ type Props = {
   threshold?: number;
   /** 오른쪽/아래 여백 커스텀 하고 싶으면 className으로 조절 */
   className?: string;
+  /** "fixed": 화면 우하단, "inline": 부모에서 위치 제어(예: sticky) */
+  position?: "fixed" | "inline";
 };
 
 export default function ScrollToTopButton({
   root,
   threshold = 300,
   className,
+  position = "fixed",
 }: Props) {
   const themeIcon = useThemeIcon(); // "oz_dark" | "oz_light"
   const [visible, setVisible] = useState(false);
@@ -73,12 +76,12 @@ export default function ScrollToTopButton({
       aria-label="맨 위로 가기"
       onClick={handleClick}
       className={clsx(
-        "fixed z-50 right-6 bottom-6 rounded-full shadow-xl border",
+        position === "fixed" ? "fixed right-6 bottom-6" : "relative", // inline 모드에서는 부모가 위치를 책임짐
+        "z-50 rounded-full shadow-xl border",
         "bg-base-100 border-base-content/20 hover:border-base-content/40",
         "transition-opacity duration-300 ease-out",
         "focus:outline-none focus:ring-2 focus:ring-primary/50",
         "p-3",
-        // 보이기/숨기기
         visible ? "opacity-100" : "opacity-0 pointer-events-none",
         className
       )}
@@ -86,7 +89,7 @@ export default function ScrollToTopButton({
       <img
         src={iconSrc}
         alt="맨 위로"
-        className="w-6 h-6 md:w-7 md:h-7 select-none"
+        className="w-6 h-6 md:w-7 md:h-7"
         draggable={false}
       />
     </button>

--- a/src/components/commons/ScrollToTop/ScrollToTopButton.tsx
+++ b/src/components/commons/ScrollToTop/ScrollToTopButton.tsx
@@ -77,7 +77,7 @@ export default function ScrollToTopButton({
       onClick={handleClick}
       className={clsx(
         position === "fixed" ? "fixed right-6 bottom-6" : "relative", // inline 모드에서는 부모가 위치를 책임짐
-        "z-50 rounded-full shadow-xl border",
+        "z-[1000] rounded-full shadow-xl border",
         "bg-base-100 border-base-content/20 hover:border-base-content/40",
         "transition-opacity duration-300 ease-out",
         "focus:outline-none focus:ring-2 focus:ring-primary/50",

--- a/src/components/commons/ScrollToTop/index.ts
+++ b/src/components/commons/ScrollToTop/index.ts
@@ -1,0 +1,3 @@
+export { default as EnsureDefaultScrollRoot } from "./EnsureDefaultScrollRoot";
+export { default as LockOutletScrollWhenChildRoot } from "./LockOutletScrollWhenChildRoot";
+export { default as OutletWithScrollToTop } from "./OutletWithScrollToTop";

--- a/src/components/commons/ScrollToTop/scroll-root-store.ts
+++ b/src/components/commons/ScrollToTop/scroll-root-store.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+export type ScrollRoot = HTMLElement | null;
+export type ScrollRootCtx = {
+  root: ScrollRoot;
+  setRoot: (el: ScrollRoot) => void;
+};
+
+export const ScrollRootContext = createContext<ScrollRootCtx | null>(null);

--- a/src/components/commons/ScrollToTop/useScrollRoot.ts
+++ b/src/components/commons/ScrollToTop/useScrollRoot.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+import { ScrollRootContext } from "./scroll-root-store";
+
+export function useScrollRoot() {
+  const ctx = useContext(ScrollRootContext);
+  if (!ctx)
+    throw new Error("useScrollRoot must be used within <ScrollRootProvider>");
+  return ctx;
+}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,6 +1,6 @@
 import { Link, Outlet } from "react-router-dom";
 import Sidebar from "@components/Sidebar/Sidebar";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import NavUnifiedSearch from "@src/components/navigation/NavUnifiedSearch";
 import { useThemeIcon } from "@src/hooks/useThemeIcon";
 import { logos } from "@src/assets";
@@ -11,12 +11,29 @@ import ScrollToTopButton from "@components/commons/ScrollToTop/ScrollToTopButton
 import ScrollRootProvider from "@components/commons/ScrollToTop/ScrollRootProvider";
 import { useScrollRoot } from "@components/commons/ScrollToTop/useScrollRoot";
 
+// 맨 위로 가기 기본 루트 보장 헬퍼
+function EnsureDefaultScrollRoot({
+  elRef,
+}: {
+  elRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const { root, setRoot } = useScrollRoot();
+  useEffect(() => {
+    // root가 비어 있을 때만 기본 루트로 설정 (PostList가 있으면 그쪽이 덮어씀)
+    if (!root && elRef.current) {
+      setRoot(elRef.current);
+    }
+  }, [root, setRoot, elRef]);
+  return null;
+}
+
+// Outlet에 맨 위로 가기 버튼 붙임
 function OutletWithScrollToTop() {
   const { root } = useScrollRoot();
   return (
     <div className="relative w-full">
       <Outlet />
-      {/* 레이아웃 안쪽 우하단 고정(sticky). root는 페이지가 등록한 내부 스크롤 엘리먼트 */}
+      {/* root는 페이지가 등록한 내부 스크롤 엘리먼트 */}
       <div className="sticky bottom-6 w-full pointer-events-none z-[200]">
         <div className="flex justify-end">
           <div className="pointer-events-auto translate-x-2">
@@ -38,6 +55,8 @@ export default function MainLayout() {
       logo: dark ? logos.symbol.dark : logos.symbol.light,
     };
   }, [themeIcon]);
+
+  const outletScrollRef = useRef<HTMLDivElement | null>(null);
 
   // 브라우저 창 너비를 감지해 광고 배너를 노출할지 결정
   useEffect(() => {
@@ -66,8 +85,13 @@ export default function MainLayout() {
             </Link>
             <NavUnifiedSearch className="w-full" placeholder="통합검색" />
           </div>
-          <div className="flex justify-center overflow-y-auto overflow-x-visible scrollbar-hide p-2">
+          <div
+            ref={outletScrollRef}
+            className="flex justify-center overflow-y-auto overflow-x-visible scrollbar-hide p-2"
+          >
             <ScrollRootProvider>
+              {/* root가 비면 Outlet 스크롤 div를 기본 루트로 설정 */}
+              <EnsureDefaultScrollRoot elRef={outletScrollRef} />
               <OutletWithScrollToTop />
             </ScrollRootProvider>
           </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -7,6 +7,26 @@ import { logos } from "@src/assets";
 import { PATHS } from "@src/constants/paths";
 import AdBanner from "@src/components/AdBanner/AdBanner";
 import AdYoutube from "@src/components/AdBanner/AdYoutube";
+import ScrollToTopButton from "@components/commons/ScrollToTop/ScrollToTopButton";
+import ScrollRootProvider from "@components/commons/ScrollToTop/ScrollRootProvider";
+import { useScrollRoot } from "@components/commons/ScrollToTop/useScrollRoot";
+
+function OutletWithScrollToTop() {
+  const { root } = useScrollRoot();
+  return (
+    <div className="relative w-full">
+      <Outlet />
+      {/* 레이아웃 안쪽 우하단 고정(sticky). root는 페이지가 등록한 내부 스크롤 엘리먼트 */}
+      <div className="sticky bottom-6 w-full pointer-events-none z-[200]">
+        <div className="flex justify-end">
+          <div className="pointer-events-auto translate-x-2">
+            <ScrollToTopButton position="inline" root={root} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function MainLayout() {
   const [showAd, setShowAd] = useState(false);
@@ -47,7 +67,9 @@ export default function MainLayout() {
             <NavUnifiedSearch className="w-full" placeholder="통합검색" />
           </div>
           <div className="flex justify-center overflow-y-auto overflow-x-visible scrollbar-hide p-2">
-            <Outlet />
+            <ScrollRootProvider>
+              <OutletWithScrollToTop />
+            </ScrollRootProvider>
           </div>
         </div>
       </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -11,6 +11,26 @@ import ScrollToTopButton from "@components/commons/ScrollToTop/ScrollToTopButton
 import ScrollRootProvider from "@components/commons/ScrollToTop/ScrollRootProvider";
 import { useScrollRoot } from "@components/commons/ScrollToTop/useScrollRoot";
 
+// Outlet 스크롤 잠금/해제 헬퍼(내부 스크롤 루트가 활성일 때 바깥 스크롤 방지)
+function LockOutletScrollWhenChildRoot({
+  elRef,
+}: {
+  elRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const { root } = useScrollRoot();
+  useEffect(() => {
+    const el = elRef.current;
+    if (!el) return;
+    const shouldLock = root && el !== root; // 내부(PostList 등)가 루트인 경우
+    const prev = el.style.overflowY;
+    el.style.overflowY = shouldLock ? "hidden" : "auto";
+    return () => {
+      el.style.overflowY = prev || "auto";
+    };
+  }, [root, elRef]);
+  return null;
+}
+
 // 맨 위로 가기 기본 루트 보장 헬퍼
 function EnsureDefaultScrollRoot({
   elRef,
@@ -92,6 +112,7 @@ export default function MainLayout() {
             <ScrollRootProvider>
               {/* root가 비면 Outlet 스크롤 div를 기본 루트로 설정 */}
               <EnsureDefaultScrollRoot elRef={outletScrollRef} />
+              <LockOutletScrollWhenChildRoot elRef={outletScrollRef} />
               <OutletWithScrollToTop />
             </ScrollRootProvider>
           </div>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet } from "react-router-dom";
+import { Link } from "react-router-dom";
 import Sidebar from "@components/Sidebar/Sidebar";
 import { useEffect, useMemo, useRef, useState } from "react";
 import NavUnifiedSearch from "@src/components/navigation/NavUnifiedSearch";
@@ -7,63 +7,12 @@ import { logos } from "@src/assets";
 import { PATHS } from "@src/constants/paths";
 import AdBanner from "@src/components/AdBanner/AdBanner";
 import AdYoutube from "@src/components/AdBanner/AdYoutube";
-import ScrollToTopButton from "@components/commons/ScrollToTop/ScrollToTopButton";
 import ScrollRootProvider from "@components/commons/ScrollToTop/ScrollRootProvider";
-import { useScrollRoot } from "@components/commons/ScrollToTop/useScrollRoot";
-
-// Outlet 스크롤 잠금/해제 헬퍼(내부 스크롤 루트가 활성일 때 바깥 스크롤 방지)
-function LockOutletScrollWhenChildRoot({
-  elRef,
-}: {
-  elRef: React.RefObject<HTMLDivElement | null>;
-}) {
-  const { root } = useScrollRoot();
-  useEffect(() => {
-    const el = elRef.current;
-    if (!el) return;
-    const shouldLock = root && el !== root; // 내부(PostList 등)가 루트인 경우
-    const prev = el.style.overflowY;
-    el.style.overflowY = shouldLock ? "hidden" : "auto";
-    return () => {
-      el.style.overflowY = prev || "auto";
-    };
-  }, [root, elRef]);
-  return null;
-}
-
-// 맨 위로 가기 기본 루트 보장 헬퍼
-function EnsureDefaultScrollRoot({
-  elRef,
-}: {
-  elRef: React.RefObject<HTMLDivElement | null>;
-}) {
-  const { root, setRoot } = useScrollRoot();
-  useEffect(() => {
-    // root가 비어 있을 때만 기본 루트로 설정 (PostList가 있으면 그쪽이 덮어씀)
-    if (!root && elRef.current) {
-      setRoot(elRef.current);
-    }
-  }, [root, setRoot, elRef]);
-  return null;
-}
-
-// Outlet에 맨 위로 가기 버튼 붙임
-function OutletWithScrollToTop() {
-  const { root } = useScrollRoot();
-  return (
-    <div className="relative w-full">
-      <Outlet />
-      {/* root는 페이지가 등록한 내부 스크롤 엘리먼트 */}
-      <div className="sticky bottom-6 w-full pointer-events-none z-[200]">
-        <div className="flex justify-end">
-          <div className="pointer-events-auto translate-x-2">
-            <ScrollToTopButton position="inline" root={root} />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
+import {
+  EnsureDefaultScrollRoot,
+  LockOutletScrollWhenChildRoot,
+  OutletWithScrollToTop,
+} from "@components/commons/ScrollToTop";
 
 export default function MainLayout() {
   const [showAd, setShowAd] = useState(false);
@@ -110,7 +59,6 @@ export default function MainLayout() {
             className="flex justify-center overflow-y-auto overflow-x-visible scrollbar-hide p-2"
           >
             <ScrollRootProvider>
-              {/* root가 비면 Outlet 스크롤 div를 기본 루트로 설정 */}
               <EnsureDefaultScrollRoot elRef={outletScrollRef} />
               <LockOutletScrollWhenChildRoot elRef={outletScrollRef} />
               <OutletWithScrollToTop />

--- a/src/pages/boards/GithubListPage.tsx
+++ b/src/pages/boards/GithubListPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import GithubList from "@components/Board/github/GithubList";
 import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
@@ -8,6 +8,7 @@ import { useGithubPosts, useGithubListWithLinks } from "@hooks/useGithubPosts";
 import type { SortValue } from "@src/types/sort";
 import type { PositionValue } from "@src/types/tag";
 import { posToTagClass } from "@utils/tagRules";
+import { useScrollRoot } from "@components/commons/ScrollToTop/useScrollRoot";
 
 export default function GithubListPage() {
   const nav = useNavigate();
@@ -74,6 +75,13 @@ export default function GithubListPage() {
     }
     return "GitHub 게시판 목록을 불러오는 중 문제가 발생했습니다.";
   }, [isError, error]);
+
+  const { setRoot } = useScrollRoot();
+
+  useEffect(() => {
+    setRoot(rootEl);
+    return () => setRoot(null);
+  }, [rootEl, setRoot]);
 
   return (
     <div className="self-stretch w-[800px] max-w-full p-4">

--- a/src/pages/boards/PostListPage.tsx
+++ b/src/pages/boards/PostListPage.tsx
@@ -1,3 +1,4 @@
+// PostListPage.tsx (정리된 최종본)
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import PostList from "@src/components/Board/free/PostList";
@@ -23,6 +24,7 @@ const BOARD_LABEL: Record<BoardSlug, string> = {
 
 export default function PostListPage({ board }: { board: BoardSlug }) {
   const nav = useNavigate();
+
   const [lastLoadedAt, setLastLoadedAt] = useState(
     formatYyyyMmDdHms(new Date())
   );
@@ -57,9 +59,6 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
   } = useBoardPosts(board, {
     pageSize: LIST_SETTINGS.ITEMS_PER_PAGE,
     sort,
-    // search,                // TODO(filter): 검색어 연결
-
-    // 필터 적용된 경우에만 태그 파라미터 전송 → 포지션 & 기수 AND
     tags: activeFilter
       ? {
           tagClass: posToTagClass(activeFilter.pos),
@@ -70,10 +69,9 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
 
   // pages(flat) → PostListItem[]
   const items = useMemo(() => (data?.pages ?? []).flat(), [data]);
-
   const uiItems = useMemo(() => items.map(mapToFreeItem), [items]);
 
-  // 작성자 라벨 맵: postId → "11기 · 프론트" 등
+  // 작성자 라벨 맵
   const authorLabelMap = useMemo(() => {
     const m = new Map<number, string>();
     for (const p of items) {
@@ -103,13 +101,18 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
 
   const handleRefresh = useCallback(() => {
     setLastLoadedAt(formatYyyyMmDdHms(new Date()));
-    refetch(); // infiniteQuery 캐시 유지한 채 재요청
+    refetch();
   }, [refetch]);
 
   const errorText =
     isError && error && typeof error === "object" && "message" in error
       ? (error as { message?: string }).message
       : ERROR_MESSAGES.LOAD_POSTS;
+
+  // PostList의 스크롤 div가 마운트되는 순간 여기에도 공유 (무한스크롤 root용)
+  const attachScrollRoot = useCallback((el: HTMLDivElement | null) => {
+    setRootEl(el);
+  }, []);
 
   return (
     <div className="self-stretch w-[800px] max-w-full p-4">
@@ -128,7 +131,7 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
           errorText={isError ? errorText : undefined}
           hasMore={!!hasNextPage}
           sentinelRef={sentinelRef}
-          scrollRootRef={setRootEl}
+          scrollRootRef={attachScrollRoot}
           empty={{ message: "등록된 게시글이 없습니다." }}
           className="py-2"
           renderAuthorLabel={(it) => authorLabelMap.get(Number(it.id)) ?? ""}
@@ -144,9 +147,9 @@ export default function PostListPage({ board }: { board: BoardSlug }) {
             if (next) {
               setPos(next.pos);
               setCohort(next.cohort);
-              setActiveFilter(next); // 필터 적용
+              setActiveFilter(next);
             } else {
-              setActiveFilter(null); // 전체 보기
+              setActiveFilter(null);
             }
             setLastLoadedAt(formatYyyyMmDdHms(new Date()));
             rootEl?.scrollTo({ top: 0, behavior: "instant" as ScrollBehavior });

--- a/src/pages/boards/SurveyListPage.tsx
+++ b/src/pages/boards/SurveyListPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { SurveyList } from "@components/Board/survey";
 import { useInfiniteScroll } from "@hooks/useInfiniteScroll";
@@ -10,6 +10,7 @@ import sortClientSide from "@src/utils/sortClientSide";
 import type { PositionValue } from "@src/types/tag";
 import { posToTagClass } from "@utils/tagRules";
 import type { SortableSurveyCard } from "@src/hooks/useSurveys";
+import { useScrollRoot } from "@components/commons/ScrollToTop/useScrollRoot";
 
 export default function SurveyListPage() {
   const nav = useNavigate();
@@ -82,6 +83,13 @@ export default function SurveyListPage() {
     isError && error && typeof error === "object" && "message" in error
       ? (error as { message?: string }).message
       : "설문 목록을 불러오는 중 문제가 발생했습니다.";
+
+  const { setRoot } = useScrollRoot();
+
+  useEffect(() => {
+    setRoot(rootEl);
+    return () => setRoot(null);
+  }, [rootEl, setRoot]);
 
   return (
     <div className="self-stretch w-[800px] max-w-full p-4">


### PR DESCRIPTION
스크롤 컨텍스트로 감싸고, 훅 사용하여 적용해야 하는 곳에 사용.
가장 위 기준 300px 이상 y축 스크롤 다운시, 맨 위로 가기 버튼 활성화, fade-in.
스크롤 업 혹은 300px 미만의 경우, 맨 위로 가기 버튼 fade-out.
테마 변경 반영.

게시판 페이지는 루트 스크롤이 따로 있어서, 메인 레이아웃과 별도로 작업했습니다.
`EnsureDefaultScrollRoot.tsx`, `OutletWithScrollToTop`

메인 레이아웃에서 게시판 페이지 안쪽 스크롤 말고 페이지 자체가 스크롤되는 이슈도 해결했습니다. (내부 스크롤 루트가 활성일 때 바깥 스크롤 방지 - `LockOutletScrollWhenChildRoot.tsx`)

<img width="888" height="793" alt="image" src="https://github.com/user-attachments/assets/9afa16f6-a5c8-4b5e-8f6d-599e8be1744d" />
<img width="895" height="814" alt="image" src="https://github.com/user-attachments/assets/dba3606d-55e0-4ddf-a521-f882877db92e" />
<img width="883" height="814" alt="image" src="https://github.com/user-attachments/assets/bae71ff1-d207-496c-aeff-71fecc4a2372" />
<img width="945" height="917" alt="image" src="https://github.com/user-attachments/assets/3d891917-4f6a-413a-bb9a-df5ce06df99a" />
<img width="194" height="122" alt="image" src="https://github.com/user-attachments/assets/5f63a970-f62c-4f2c-a563-aa7517d40099" />


---

closes #14 