### PR TITLE
[feat] 알림 로직과 UI 보충 및 마무리

### DIFF
--- a/src/components/Notice/NoticeCard.tsx
+++ b/src/components/Notice/NoticeCard.tsx
@@ -100,11 +100,16 @@ export default function NoticeCard({
         <button
           type="button"
           aria-label="알림 삭제"
+          onPointerDown={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
           onClick={(e) => {
             e.stopPropagation();
+            e.preventDefault();
             onDelete();
           }}
-          className="absolute right-2 top-2 w-6 h-6 rounded-full flex items-center justify-center opacity-90 hover:opacity-100 z-[1]"
+          className="absolute right-2 top-2 w-7 h-7 md:w-8 md:h-8 rounded-full flex items-center justify-center z-20 pointer-events-auto opacity-90 hover:opacity-100"
         >
           <span className="text-base text-primary-content leading-none">×</span>
         </button>

--- a/src/components/Notice/NoticeCard.tsx
+++ b/src/components/Notice/NoticeCard.tsx
@@ -10,11 +10,13 @@ export default function NoticeCard({
   deleteMode,
   onDelete,
   onMarkRead,
+  onNavigate,
 }: {
   n: Notification;
   deleteMode: boolean;
   onDelete: () => void;
   onMarkRead: () => void;
+  onNavigate?: () => void;
 }) {
   const { isDark } = useTheme();
   const navigate = useNavigate();
@@ -26,11 +28,15 @@ export default function NoticeCard({
   const clickable = !deleteMode; // 삭제모드 아닐 때만 인터랙션
 
   const busyRef = useRef(false);
+
   const handleClick = () => {
     if (!clickable || busyRef.current) return;
     busyRef.current = true;
     if (!n.read) onMarkRead();
-    if (path) navigate(path);
+    if (path) {
+      onNavigate?.(); // 모달 닫고
+      navigate(path); // 라우팅하기
+    }
     setTimeout(() => {
       busyRef.current = false;
     }, 350);

--- a/src/components/Notice/NoticeHeader.tsx
+++ b/src/components/Notice/NoticeHeader.tsx
@@ -37,7 +37,11 @@ export default function NoticeHeader({
   };
 
   return (
-    <header className="relative z-10 h-12 px-3 md:px-4 border-b border-base-300 flex items-center justify-between">
+    <header
+      className="relative z-10 flex-none h-12 px-3 md:px-4
+                    border-b border-base-300 bg-base-200 md:rounded-t-2xl
+                    flex items-center justify-between"
+    >
       <h2 id="notice-title" className="text-base md:text-lg font-semibold">
         알림
       </h2>

--- a/src/components/Notice/NoticeList.tsx
+++ b/src/components/Notice/NoticeList.tsx
@@ -4,9 +4,11 @@ import { useNotificationList } from "@src/hooks/useNotifications";
 export default function NoticeList({
   deleteMode,
   enabled = true,
+  onItemNavigate,
 }: {
   deleteMode: boolean;
   enabled?: boolean;
+  onItemNavigate?: () => void;
 }) {
   const { items, isLoading, isError, markOne, deleteOne, refetch } =
     useNotificationList({ enabled });
@@ -49,6 +51,7 @@ export default function NoticeList({
             deleteMode={deleteMode}
             onDelete={() => deleteOne.mutate(Number(n.id))}
             onMarkRead={() => markOne.mutate(Number(n.id))}
+            onNavigate={onItemNavigate}
           />
         </li>
       ))}

--- a/src/components/Notice/NoticeList.tsx
+++ b/src/components/Notice/NoticeList.tsx
@@ -1,9 +1,18 @@
 import NoticeCard from "./NoticeCard";
 import { useNotificationList } from "@src/hooks/useNotifications";
 
-export default function NoticeList({ deleteMode }: { deleteMode: boolean }) {
-  const { items, isLoading, isError, markOne, deleteOne } =
-    useNotificationList();
+export default function NoticeList({
+  deleteMode,
+  enabled = true,
+}: {
+  deleteMode: boolean;
+  enabled?: boolean;
+}) {
+  const { items, isLoading, isError, markOne, deleteOne, refetch } =
+    useNotificationList({ enabled });
+
+  // 비활성화 상태면 렌더 안 함
+  if (!enabled) return null;
 
   if (isLoading) {
     return (
@@ -14,8 +23,11 @@ export default function NoticeList({ deleteMode }: { deleteMode: boolean }) {
   }
   if (isError) {
     return (
-      <div className="py-20 text-center text-sm text-error">
+      <div className="py-20 text-center text-sm text-error flex flex-col items-center gap-2">
         알림을 불러오지 못했어요.
+        <button className="btn btn-xs" onClick={() => refetch()}>
+          다시 시도
+        </button>
       </div>
     );
   }

--- a/src/components/Notice/NotificationModal.tsx
+++ b/src/components/Notice/NotificationModal.tsx
@@ -2,39 +2,59 @@ import { useEffect } from "react";
 import NoticeHeader from "./NoticeHeader";
 import NoticeList from "./NoticeList";
 import { useNoticeDeleteMode } from "./useNoticeDeleteMode";
-import { useNotificationList } from "@src/hooks/useNotifications";
+import {
+  useNewFlagValue,
+  useNotificationList,
+} from "@src/hooks/useNotifications";
+import { useAuthStore } from "@store/authStore";
 
 type Props = { open: boolean; onClose?: () => void };
 
 export default function NotificationModal({ open, onClose }: Props) {
+  // 인증 여부
+  const accessToken = useAuthStore((s) => s.tokens.accessToken);
+  const isOzAuthenticated = useAuthStore((s) => s.isOzAuthenticated);
+  const enabled = open && (!!accessToken || !!isOzAuthenticated);
+
+  const { refetch, markAllRead, deleteAll } = useNotificationList({ enabled });
+
+  // 전역 체크 캐시 구독 → 모달 열린 상태에서 new:true면 즉시 갱신
+  const hasNew = useNewFlagValue();
+
+  // 삭제모드 토글/리셋
   const { deleteMode, toggleDeleteMode, resetDeleteMode } =
     useNoticeDeleteMode();
-  const { markAllRead, deleteAll, refetch } = useNotificationList();
 
   const handleClose = () => {
     onClose?.();
     resetDeleteMode(); // 모달 닫힐 때 삭제모드 초기화
   };
 
+  // 1) 열릴 때마다 강제 최신화 (staleTime 무시)
+  useEffect(() => {
+    if (enabled) refetch();
+  }, [enabled, refetch]);
+
+  // 2) 모달 열린 상태에서 새 알림 감지되면 즉시 최신화
+  useEffect(() => {
+    if (open && hasNew) refetch();
+  }, [open, hasNew, refetch]);
+
+  // 3) ESC 닫기 + 바디 스크롤 잠금
   useEffect(() => {
     if (!open) return;
-    refetch();
-
-    // ESC 닫기 + 바디 스크롤 잠금
     const h = (e: KeyboardEvent) => {
       if (e.key === "Escape") handleClose();
     };
     window.addEventListener("keydown", h);
-
     const prev = document.body.style.overflow;
     document.body.style.overflow = "hidden";
-
     return () => {
       window.removeEventListener("keydown", h);
       document.body.style.overflow = prev;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, refetch]);
+  }, [open]);
 
   if (!open) return null;
 
@@ -46,6 +66,7 @@ export default function NotificationModal({ open, onClose }: Props) {
         onClick={handleClose}
         className="absolute inset-0 bg-black/60 cursor-default"
       />
+
       {/* 패널 */}
       <section
         role="dialog"
@@ -55,8 +76,8 @@ export default function NotificationModal({ open, onClose }: Props) {
           absolute left-1/2 -translate-x-1/2 top-0 md:top-20
           w-full md:w-[560px]
           h-dvh md:h-auto md:max-h-[80vh]
-          bg-base-200 md:rounded-2xl shadow-2xl
-          flex flex-col
+          bg-base-200 md:rounded-2xl md:overflow-hidden shadow-2xl
+          flex flex-col min-h-0
         "
       >
         <NoticeHeader
@@ -66,8 +87,9 @@ export default function NotificationModal({ open, onClose }: Props) {
           onMarkAllRead={() => markAllRead.mutate()}
           onDeleteAll={() => deleteAll.mutate()}
         />
-        <div className="flex-1 overflow-y-auto p-2 md:p-3">
-          <NoticeList deleteMode={deleteMode} />
+        <div className="flex-1 min-h-0 overflow-y-auto p-2 md:p-3">
+          {/* 모달 열렸고 인증일 때만 목록 쿼리 활성화 */}
+          <NoticeList deleteMode={deleteMode} enabled={enabled} />
         </div>
       </section>
     </div>

--- a/src/components/Notice/NotificationModal.tsx
+++ b/src/components/Notice/NotificationModal.tsx
@@ -89,7 +89,11 @@ export default function NotificationModal({ open, onClose }: Props) {
         />
         <div className="flex-1 min-h-0 overflow-y-auto p-2 md:p-3">
           {/* 모달 열렸고 인증일 때만 목록 쿼리 활성화 */}
-          <NoticeList deleteMode={deleteMode} enabled={enabled} />
+          <NoticeList
+            deleteMode={deleteMode}
+            enabled={enabled}
+            onItemNavigate={handleClose}
+          />
         </div>
       </section>
     </div>

--- a/src/components/Sidebar/SidebarFolded.tsx
+++ b/src/components/Sidebar/SidebarFolded.tsx
@@ -37,12 +37,12 @@ export function SidebarFolded({ onToggle }: { onToggle: () => void }) {
         />
         <button
           onClick={() => setNoticeOpen(true)}
-          className="p-2 rounded-full hover:bg-base-300"
+          className="relative p-2 rounded-full hover:bg-base-300"
         >
           <img src={notificationsIcon} alt="notificationsIcon" />
           {hasNew && (
             <i
-              className="absolute right-2 top-2 w-2 h-2 rounded-full bg-error"
+              className="absolute right-1.5 top-1.5 w-2 h-2 rounded-full bg-[#F43535] z-10"
               aria-hidden
             />
           )}

--- a/src/components/Sidebar/SidebarOpen.tsx
+++ b/src/components/Sidebar/SidebarOpen.tsx
@@ -46,12 +46,12 @@ export function SidebarOpen({ onToggle }: { onToggle: () => void }) {
           <div className="flex justify-between w-[270px] h-[40px]">
             <button
               onClick={() => setNoticeOpen(true)}
-              className="p-2 rounded-full hover:bg-base-300"
+              className="relative p-2 rounded-full hover:bg-base-300"
             >
               <img src={notificationsIcon} alt="notificationsIcon" />
               {hasNew && (
                 <i
-                  className="absolute right-2 top-2 w-2 h-2 rounded-full bg-error"
+                  className="absolute right-1.5 top-1.5 w-2 h-2 rounded-full bg-[#F43535] z-10"
                   aria-hidden
                 />
               )}

--- a/src/features/notifications/notice.adapter.ts
+++ b/src/features/notifications/notice.adapter.ts
@@ -1,21 +1,54 @@
 import type { ApiNotification } from "@api/notifications";
 import type { Notification } from "@components/Notice/notice.types";
+import { PATHS } from "@src/constants/paths";
+
+function stripNickSegments(s?: string | null) {
+  if (!s) return "";
+  const OPEN = "[[NICK]]";
+  const CLOSE = "[[/NICK]]";
+  let out = "";
+  let i = 0;
+
+  while (i < s.length) {
+    const a = s.indexOf(OPEN, i);
+    if (a === -1) {
+      out += s.slice(i);
+      break;
+    }
+    out += s.slice(i, a);
+    const b = s.indexOf(CLOSE, a + OPEN.length);
+    if (b === -1) {
+      break;
+    }
+    i = b + CLOSE.length;
+  }
+  return out.replace(/\s{2,}/g, " ").trim();
+}
+
+const toPostPath = (id: number) =>
+  (PATHS?.POST_DETAIL ?? "/posts/:id").replace(":id", String(id));
 
 export function mapApiToNotice(n: ApiNotification): Notification {
   const hasPost = !!n.post;
+  const title = n.post?.title ?? "";
+  const path = hasPost ? toPostPath(n.post!.id) : undefined;
+
+  // 닉네임 지우기
+  const cleanMsg = stripNickSegments(n.message);
+
+  // 첫째 줄: 게시글 제목 기반 안내문
+  const text = hasPost ? `“${title}” 에 댓글이 달렸습니다.` : cleanMsg;
+
+  // 둘째 줄: 실제 댓글 내용(message)- 비어있으면 게시글 제목으로 폴백
+  const detail = cleanMsg || title;
+
   return {
     id: String(n.id),
     type: hasPost ? "comment" : "system",
-    text: n.message,
-    detail: hasPost ? n.post!.title : n.message,
+    text,
+    detail,
     read: n.is_read,
     createdAt: n.created_at,
-    context: hasPost
-      ? {
-          title: n.post!.title,
-          path: `/posts/${n.post!.id}`,
-          myComment: undefined,
-        }
-      : undefined,
+    context: hasPost ? { title, path } : undefined,
   };
 }


### PR DESCRIPTION
- 게시글 연결 + 읽음 처리
- 알림 30초 주기 폴링 시 새 알림 발생 + 알림 모달 연 상황에서도 refetch되도록 함
- 스크롤 생긴 경우 알림 헤더 좁아지는 이슈 해결
- 스크롤 영역 확보는 스크롤 없을 때 UI가 좋지 못하여 추가 X
- 안 읽은 알림 있을 때 사이드바 알림 아이콘에 점 달리게 함
- 삭제 버튼 잘 안 눌리는 거 수정
- 알림 카드 클릭하여 해당 게시글로 이동 시 알림 모달 닫히게 함
- 메시지 본문 보이게 하기 (댓글 내용) + 닉네임은 제거

이외 기본 삭제, 읽음 처리 확인 완료했습니다.

<img width="58" height="57" alt="image" src="https://github.com/user-attachments/assets/ad7afd91-6197-4929-9478-60fcebebf477" />
<img width="623" height="215" alt="image" src="https://github.com/user-attachments/assets/3a5407e6-6736-41ae-97a2-d4734defdc33" />

---

closes #216 
