### PR TITLE
[feat] 테스트 허브 라우트 삭제 및 키인증 팝업 API 연결

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -48,7 +48,8 @@ export async function loginWithGoogle(
 export async function activateWithKey(params: {
   idToken: string;
   cohortNumber: number;
-  plainKey: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  plainKey: any;
 }): Promise<ActivateResponse> {
   const { idToken, cohortNumber, plainKey } = params;
 

--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -1,6 +1,4 @@
 import api from "@api/client";
-import { tokenStore } from "@api/client";
-import { useAuthStore } from "@store/authStore";
 
 /** 서버 원본 타입 */
 export type ApiNotification = {
@@ -11,49 +9,34 @@ export type ApiNotification = {
   created_at: string; // ISO
 };
 
-/** 풀 인증(액세스 토큰 + 오즈 인증 완료) 확인 */
-function isFullyAuthed(): boolean {
-  const hasAccess = Boolean(tokenStore.access);
-  const ozOk = useAuthStore.getState().isOzAuthenticated === true;
-  return hasAccess && ozOk;
-}
-
 /** 목록: GET /api/ntf/ */
 export async function fetchNotifications(): Promise<ApiNotification[]> {
-  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
   const { data } = await api.get<ApiNotification[]>("/api/ntf/");
   return data;
 }
 
 /** 전체 읽음: PATCH /api/ntf/ */
 export async function markAllRead(): Promise<void> {
-  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
   await api.patch("/api/ntf/", {}); // 바디 필요 없으므로 빈 객체
 }
 
 /** 전체 삭제: DELETE /api/ntf/ */
 export async function deleteAllNotifications(): Promise<void> {
-  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
   await api.delete("/api/ntf/");
 }
 
-/** 개별 읽음: PATCH /api/ntf/{id}/ */
+/** 개별 읽음: PATCH /api/ntf/{id} */
 export async function markOneRead(id: number): Promise<void> {
-  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
-  await api.patch(`/api/ntf/${id}/`, {}); // DRF trailing slash & 빈 바디
+  await api.patch(`/api/ntf/${id}`);
 }
 
-/** 개별 삭제: DELETE /api/ntf/{id}/ */
+/** 개별 삭제: DELETE /api/ntf/{id} */
 export async function deleteOne(id: number): Promise<void> {
-  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
-  await api.delete(`/api/ntf/${id}/`);
+  await api.delete(`/api/ntf/${id}`);
 }
 
-/** 새 알림 여부: GET /api/ntf/check/ -> { new: boolean }
- *  로그인+미인증 단계에서는 조용히 { new:false } 반환 (UX 위해 에러 미노출)
- */
+/** 새 알림 여부: GET /api/ntf/check  -> { new: boolean } */
 export async function checkNew(): Promise<{ new: boolean }> {
-  if (!isFullyAuthed()) return { new: false };
-  const { data } = await api.get<{ new: boolean }>("/api/ntf/check/");
+  const { data } = await api.get<{ new: boolean }>("/api/ntf/check");
   return data;
 }

--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -1,4 +1,6 @@
 import api from "@api/client";
+import { tokenStore } from "@api/client";
+import { useAuthStore } from "@store/authStore";
 
 /** 서버 원본 타입 */
 export type ApiNotification = {
@@ -9,34 +11,49 @@ export type ApiNotification = {
   created_at: string; // ISO
 };
 
+/** 풀 인증(액세스 토큰 + 오즈 인증 완료) 확인 */
+function isFullyAuthed(): boolean {
+  const hasAccess = Boolean(tokenStore.access);
+  const ozOk = useAuthStore.getState().isOzAuthenticated === true;
+  return hasAccess && ozOk;
+}
+
 /** 목록: GET /api/ntf/ */
 export async function fetchNotifications(): Promise<ApiNotification[]> {
+  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
   const { data } = await api.get<ApiNotification[]>("/api/ntf/");
   return data;
 }
 
 /** 전체 읽음: PATCH /api/ntf/ */
 export async function markAllRead(): Promise<void> {
+  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
   await api.patch("/api/ntf/", {}); // 바디 필요 없으므로 빈 객체
 }
 
 /** 전체 삭제: DELETE /api/ntf/ */
 export async function deleteAllNotifications(): Promise<void> {
+  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
   await api.delete("/api/ntf/");
 }
 
-/** 개별 읽음: PATCH /api/ntf/{id} */
+/** 개별 읽음: PATCH /api/ntf/{id}/ */
 export async function markOneRead(id: number): Promise<void> {
-  await api.patch(`/api/ntf/${id}`);
+  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
+  await api.patch(`/api/ntf/${id}/`, {}); // DRF trailing slash & 빈 바디
 }
 
-/** 개별 삭제: DELETE /api/ntf/{id} */
+/** 개별 삭제: DELETE /api/ntf/{id}/ */
 export async function deleteOne(id: number): Promise<void> {
-  await api.delete(`/api/ntf/${id}`);
+  if (!isFullyAuthed()) throw new Error("로그인/인증 후 이용 가능합니다.");
+  await api.delete(`/api/ntf/${id}/`);
 }
 
-/** 새 알림 여부: GET /api/ntf/check  -> { new: boolean } */
+/** 새 알림 여부: GET /api/ntf/check/ -> { new: boolean }
+ *  로그인+미인증 단계에서는 조용히 { new:false } 반환 (UX 위해 에러 미노출)
+ */
 export async function checkNew(): Promise<{ new: boolean }> {
-  const { data } = await api.get<{ new: boolean }>("/api/ntf/check");
+  if (!isFullyAuthed()) return { new: false };
+  const { data } = await api.get<{ new: boolean }>("/api/ntf/check/");
   return data;
 }

--- a/src/components/SettingModal/AccountDeletionSection.tsx
+++ b/src/components/SettingModal/AccountDeletionSection.tsx
@@ -5,6 +5,7 @@ import { tokenStore } from "@api/client";
 import { useToastStore } from "@store/toastStore";
 import { PATHS } from "@constants/paths";
 import { useLogoutMutation } from "@hooks/useAuthQueries";
+import type { AxiosError } from "axios"; // ✅ 추가
 
 interface AccountDeletionSectionProps {
   onSuccess?: () => void;
@@ -26,9 +27,10 @@ export function AccountDeletionSection({
   const handleDelete = async () => {
     if (!isValid) return;
 
-    const idToken = tokenStore.access;
-    if (!idToken) {
-      setError("로그인 후에만 회원 탈퇴가 가능합니다.");
+    const access = tokenStore.access;
+
+    if (!access) {
+      setError("오즈키 인증을 완료한 후 탈퇴가 가능합니다.");
       return;
     }
 
@@ -37,23 +39,29 @@ export function AccountDeletionSection({
 
     try {
       await deleteAccount();
+
       setIsConfirmVisible(false);
-      tokenStore.clear(); // 탈퇴 성공 시 토큰 초기화
+      tokenStore.clear();
       if (onSuccess) onSuccess();
-      navigate(PATHS.ROOT, { replace: true });
+
       await logoutMut.mutateAsync();
+
       useToastStore.getState().push({
-        // toast
         message: "회원 탈퇴에 성공했어요.",
         type: "success",
         durationMs: 4000,
       });
+
+      navigate(PATHS.ROOT, { replace: true });
     } catch (err: unknown) {
-      if (err instanceof Error) {
-        setError(err.message);
-      } else {
-        setError("회원 탈퇴 중 알 수 없는 오류가 발생했습니다.");
+      let msg = "회원 탈퇴 중 알 수 없는 오류가 발생했습니다.";
+      if ((err as AxiosError)?.response?.data) {
+        const data = (err as AxiosError<{ error?: string }>).response?.data;
+        msg = data?.error ?? msg;
+      } else if (err instanceof Error) {
+        msg = err.message;
       }
+      setError(msg);
     } finally {
       setLoading(false);
     }

--- a/src/components/SettingModal/KeySection.tsx
+++ b/src/components/SettingModal/KeySection.tsx
@@ -1,51 +1,109 @@
 import { useState } from "react";
-import { tokenStore } from "@api/client";
+import { useNavigate } from "react-router-dom";
+import type { AxiosError } from "axios";
+import { PATHS } from "@constants/paths";
+import { useToastStore } from "@store/toastStore";
+import {
+  useGetCurrentUserQuery,
+  useActivateWithKeyMutation,
+} from "@hooks/useAuthQueries";
+import { useAuthStore } from "@store/authStore";
+
+function getErrorMessage(err: unknown): string {
+  const ax = err as AxiosError<{
+    error?: string;
+    detail?: string;
+    message?: string;
+  }>;
+  return (
+    ax?.response?.data?.error ??
+    ax?.response?.data?.detail ??
+    ax?.response?.data?.message ??
+    ax?.message ??
+    "인증 실패"
+  );
+}
 
 export function KeySection() {
-  const [key, setKey] = useState<string>("");
-  const [error, setError] = useState<string>("");
-  const idToken = tokenStore.access;
+  const [key, setKey] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+  const { push } = useToastStore();
 
-  const handleLogin = (): void => {
-    if (key === "123") {
-      setError("");
-      alert("로그인 성공");
-    } else {
-      setError("유효하지 않은 키입니다.");
+  const activateMut = useActivateWithKeyMutation();
+  const currentUserQuery = useGetCurrentUserQuery(false);
+
+  const alreadyVerified = useAuthStore((s) => s.isOzAuthenticated === true);
+
+  const cohortNumber = Number(import.meta.env.VITE_COHORT_NUMBER);
+
+  if (alreadyVerified) {
+    return (
+      <div className="border-b border-neutral-content py-6">
+        <p className="mb-2">회원 인증</p>
+        <div className="p-3 w-full bg-base-300 text-secondary rounded-md">
+          이미 인증된 사용자입니다.
+        </div>
+      </div>
+    );
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+
+    const pendingIdt = sessionStorage.getItem("oz_pending_idt");
+    if (!pendingIdt) {
+      push({
+        message: "인증 토큰이 없습니다. 다시 로그인 해주세요.",
+        type: "error",
+      });
+      navigate(PATHS.AUTH, { replace: true });
+      return;
     }
-  };
+
+    try {
+      const res = await activateMut.mutateAsync({
+        idToken: pendingIdt,
+        cohortNumber,
+        plainKey: key,
+      });
+
+      sessionStorage.removeItem("oz_pending_idt");
+      await currentUserQuery.refetch();
+
+      push({ message: "오즈키 인증 완료!", type: "success" });
+
+      const next = typeof res?.next === "string" ? res.next : PATHS.MAIN;
+      navigate(next, { replace: true });
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+    }
+  }
+
+  const disabled = activateMut.isPending;
 
   return (
     <div className="border-b border-neutral-content py-6">
       <p className="mb-2">회원 인증</p>
-      {idToken ? (
-        <div className=" p-3 w-full bg-base-300 text-secondary rounded-md">
-          이미 인증된 사용자입니다.
-        </div>
-      ) : (
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            handleLogin();
-          }}
-          className="flex justify-between"
+      <form onSubmit={onSubmit} className="flex gap-2">
+        <input
+          type="text"
+          placeholder="발급받은 인증 키를 입력해 주세요."
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          className="flex-1 min-w-0 bg-base-300 border border-base-200 p-2 focus:outline-none focus:border-primary rounded"
+          disabled={disabled}
+        />
+        <button
+          type="submit"
+          className={`px-4 text-white py-2 rounded transition ${disabled ? "btn loading" : "bg-primary hover:bg-secondary"}`}
+          disabled={disabled}
         >
-          <input
-            type="text"
-            placeholder="발급받은 인증 키를 입력해 주세요."
-            value={key}
-            onChange={(e) => setKey(e.target.value)}
-            className="flex-1 min-w-0 bg-base-300 border border-base-200 p-2 focus:outline-none focus:border-primary rounded"
-          />
-          <button
-            type="submit"
-            className="px-4 bg-primary text-white py-2 rounded hover:bg-secondary transition"
-          >
-            인증
-          </button>
-        </form>
-      )}
-      {error && <p className="text-error font-thin">{error}</p>}
+          {disabled ? "인증 중..." : "인증"}
+        </button>
+      </form>
+      {error && <p className="text-error font-thin mt-2">{error}</p>}
     </div>
   );
 }

--- a/src/components/SettingModal/SettingsPopup.tsx
+++ b/src/components/SettingModal/SettingsPopup.tsx
@@ -2,7 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { KeySection } from "./KeySection";
 import ThemeToggleSection from "./ThemeToggleSection";
 import { AccountDeletionSection } from "./AccountDeletionSection";
-import { tokenStore } from "@api/client";
+import { useAuthStore } from "@store/authStore";
 
 type Theme = "oz_dark" | "oz_light";
 
@@ -17,8 +17,7 @@ export function SettingPopup({
   theme,
   setTheme,
 }: SettingPopupProps) {
-  const idToken = tokenStore.access;
-  const isAuthenticated = Boolean(idToken);
+  const isAuthenticated = useAuthStore((s) => Boolean(s.tokens.accessToken));
 
   return (
     <div className="relative bg-base-200 rounded-md p-6 max-w-md w-full">

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -1,6 +1,5 @@
-// constants/paths.ts
 export const PATHS = {
-  ROOT: "/", // 현재(25.08.10) 테스트 허브
+  ROOT: "/", // 루트 엔트리: 인증/오즈 인증 상태 분기
   AUTH: "/auth", // 로비(랜딩)+로그인,회원가입 페이지
   MAIN: "/main",
   KEY_VERIFY: "/key-verify",

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -51,11 +51,6 @@ function KeyVerifySettingsPage() {
       | "oz_light") ?? "oz_light"
   );
 
-  // 테마 상태 → html[data-theme] 동기화 (선택사항)
-  useEffect(() => {
-    document?.documentElement?.setAttribute("data-theme", theme);
-  }, [theme]);
-
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
       <SettingsPage

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -1,4 +1,3 @@
-// router/AppRouter.tsx - 마이페이지 라우트 추가 버전
 import {
   Routes,
   Route,
@@ -8,18 +7,12 @@ import {
 } from "react-router-dom";
 import { PATHS } from "@constants/paths";
 
-import LandingPage from "@pages/landing/LandingPage"; // /auth (로비)
-import MainPage from "@pages/main/MainPage"; // /main
+import LandingPage from "@pages/landing/LandingPage";
+import MainPage from "@pages/main/MainPage";
 import Error403 from "@pages/error/403";
 import Error404 from "@pages/error/404";
 import Error500 from "@pages/error/500";
 
-import TestHub from "@pages/test/TestHub"; // /
-import TestPostWritePage from "@pages/test/TestPostWritePage"; // /test/write
-import TestSettingPage from "@pages/test/TestSettingPage"; // /test/setting
-import TestFreeBoardList from "@src/pages/test/BoardList/TestFreeBoardList"; // test/board/free-list
-
-// 마이페이지 관련 import 추가
 import MyPageLayout from "@pages/mypage/MyPageLayout";
 import MyPageMain from "@pages/mypage/MyPageMain";
 import MyPosts from "@pages/mypage/MyPosts";
@@ -31,154 +24,64 @@ import { useAuthStore } from "@store/authStore";
 import RootLayout from "@layouts/RootLayout";
 import { redirectWithIntent } from "./guards";
 
-// 임시+테스트용: 오즈키 인증 페이지 관련 import
-import { useState, useEffect, useCallback } from "react";
-import {
-  useGetCurrentUserQuery,
-  useActivateWithKeyMutation,
-} from "@hooks/useAuthQueries";
-import { useToastStore } from "@store/toastStore";
-import { resolvePostLoginPath } from "@utils/postLogin";
-import TestTagPage from "@src/pages/test/TestTagPage";
-import TestPostReadPage from "@src/pages/test/TestPostReadPage";
-import TestSurveyList from "@src/pages/test/BoardList/TestSurveyList";
-import TestJobBannerPage from "@src/pages/test/TestJobBanner";
+import { useEffect, useCallback, useState } from "react";
 
-import { isValidOzKeyLocal, resolveCohortNumber } from "@src/utils/auth/ozKey";
-import PostDetailPage from "@src/pages/boards/PostDetailPage";
-import PostListPage from "@src/pages/boards/PostListPage";
-import SurveyListPage from "@src/pages/boards/SurveyListPage";
-
-import TestGithubList from "@src/pages/test/BoardList/TestGithubList";
-import MainLayout from "@src/layouts/MainLayout";
-import WritePostPage from "@src/components/Board/WritePostPage";
-import GithubListPage from "@src/pages/boards/GithubListPage";
+import PostDetailPage from "@pages/boards/PostDetailPage";
+import PostListPage from "@pages/boards/PostListPage";
+import SurveyListPage from "@pages/boards/SurveyListPage";
+import MainLayout from "@layouts/MainLayout";
+import WritePostPage from "@components/Board/WritePostPage";
+import GithubListPage from "@pages/boards/GithubListPage";
+import { SettingsPage } from "@components/SettingModal/SettingsPage";
 
 /** 공개(보호 불필요) 경로 목록 */
 const PUBLIC_PATHS: ReadonlySet<string> = new Set([
-  PATHS.ROOT,
   PATHS.AUTH,
   PATHS.ERROR_403,
   PATHS.ERROR_404,
   PATHS.ERROR_500,
 ]);
 
-/** 임시: 오즈키 인증 페이지 (담당자 구현 전) — 실동작 가능한 DEV 버전 */
-function KeyVerifyPlaceholder() {
-  const [plainKey, setPlainKey] = useState("");
-  const { push } = useToastStore();
-  const navigate = useNavigate();
+/** /key-verify 에서 띄울 SettingsPage 래퍼 (열림 상태/테마 상태 보관) */
+function KeyVerifySettingsPage() {
+  const [open, setOpen] = useState(true);
+  const [theme, setTheme] = useState<"oz_dark" | "oz_light">(
+    (document?.documentElement?.getAttribute("data-theme") as
+      | "oz_dark"
+      | "oz_light") ?? "oz_light"
+  );
 
-  const activateMut = useActivateWithKeyMutation();
-  const currentUserQuery = useGetCurrentUserQuery(false); // 인증 후 리프레시용
-
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    const idToken = sessionStorage.getItem("oz_pending_idt");
-    if (!idToken) {
-      push({
-        message: "인증 토큰이 없습니다. 다시 로그인 해주세요.",
-        type: "error",
-      });
-      navigate(PATHS.AUTH, { replace: true });
-      return;
-    }
-    const key = plainKey.trim();
-    if (!key) {
-      push({ message: "오즈키를 입력해 주세요.", type: "warning" });
-      return;
-    }
-
-    // ✅ 프론트 1차 검증(UX용): env의 키와 문자열 일치 확인
-    if (!isValidOzKeyLocal(key)) {
-      push({ message: "유효하지 않은 오즈키입니다.", type: "error" });
-      return;
-    }
-
-    // 코호트 번호 결정: 키에서 COHORT## 추출 → env fallback
-    let cohortNumber: number;
-    try {
-      cohortNumber = resolveCohortNumber(key);
-    } catch {
-      push({ message: "코호트 번호를 확인할 수 없습니다.", type: "error" });
-      return;
-    }
-
-    try {
-      await activateMut.mutateAsync({ idToken, cohortNumber, plainKey: key });
-
-      // 성공 → 임시 저장된 id_token 제거
-      sessionStorage.removeItem("oz_pending_idt");
-
-      // 프로필 새로고침 후 이동
-      await currentUserQuery.refetch();
-      push({ message: "오즈키 인증 완료!", type: "success" });
-      navigate(resolvePostLoginPath(true), { replace: true });
-    } catch (err: unknown) {
-      const msg =
-        typeof err === "object" && err && "message" in err
-          ? (err as { message?: string }).message ?? "인증 실패"
-          : "인증 실패";
-      push({ message: msg, type: "error" });
-    }
-  }
-
-  const disabled = activateMut.isPending;
+  // 테마 상태 → html[data-theme] 동기화 (선택사항)
+  useEffect(() => {
+    document?.documentElement?.setAttribute("data-theme", theme);
+  }, [theme]);
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4">
-      <form
-        onSubmit={onSubmit}
-        className="w_full max-w-md card bg-base-200 shadow-xl"
-      >
-        <div className="card-body">
-          <h1 className="card-title">오즈키 인증</h1>
-          <p className="text-sm opacity-80">
-            오즈키를 입력해 인증을 완료하세요.
-          </p>
-
-          <input
-            type="text"
-            value={plainKey}
-            onChange={(e) => setPlainKey(e.target.value)}
-            placeholder="예: OZ-TEST-KEY-2025-COHORT11"
-            className="input input-bordered w-full"
-            disabled={disabled}
-          />
-
-          <div className="card-actions justify-end mt-2">
-            <button
-              type="submit"
-              className={`btn btn-primary ${disabled ? "loading" : ""}`}
-              disabled={disabled}
-            >
-              {disabled ? "인증 중..." : "인증하기"}
-            </button>
-          </div>
-        </div>
-      </form>
+      <SettingsPage
+        isOpen={open}
+        setIsOpen={setOpen}
+        theme={theme}
+        setTheme={setTheme}
+      />
     </main>
   );
 }
 
 export default function AppRouter() {
-  // 앱 최초 1회 JWT/프로필 확인
   const { loading } = useAuthBootstrap();
 
-  // Zustand 셀렉터로 필요한 값만 구독 → 불필요 리렌더 줄이기
   const isAuthed = useAuthStore((s) => Boolean(s.tokens.accessToken));
   const isOzAuthenticated = useAuthStore((s) => s.isOzAuthenticated);
 
   const location = useLocation();
   const navigate = useNavigate();
 
-  // pending 상태 신호: 세션에 임시 저장된 id_token
   const pendingIdt =
     typeof window !== "undefined"
       ? sessionStorage.getItem("oz_pending_idt")
       : null;
 
-  // 같은 경로로 중복 이동 방지
   const goto = useCallback(
     (to: string) => {
       if (location.pathname !== to) navigate(to, { replace: true });
@@ -189,11 +92,9 @@ export default function AppRouter() {
   useEffect(() => {
     if (loading) return;
 
-    // A) AUTH에 있는데 로그인되면 → KEY_VERIFY 또는 MAIN
+    // A) /auth 에 있는데 로그인되면 → KEY_VERIFY 또는 MAIN
     if (location.pathname === PATHS.AUTH && isAuthed) {
-      const next = isOzAuthenticated
-        ? resolvePostLoginPath(true)
-        : PATHS.KEY_VERIFY;
+      const next = isOzAuthenticated ? PATHS.MAIN : PATHS.KEY_VERIFY;
       goto(next);
       return;
     }
@@ -203,7 +104,6 @@ export default function AppRouter() {
       PUBLIC_PATHS.has(location.pathname) ||
       (location.pathname === PATHS.KEY_VERIFY && Boolean(pendingIdt));
 
-    // B-1) 보호 라우트인데 로그인 없고, KEY_VERIFY도 아니면 → AUTH로
     if (!isAuthed && !isPublic) {
       const next = `${PATHS.AUTH}?next=${encodeURIComponent(
         location.pathname + location.search
@@ -212,7 +112,7 @@ export default function AppRouter() {
       return;
     }
 
-    // C) KEY_VERIFY 중 인증 완료되면 → MAIN
+    // C) /key-verify 에서 인증이 끝났다면 → /main
     if (
       location.pathname === PATHS.KEY_VERIFY &&
       isAuthed &&
@@ -226,44 +126,40 @@ export default function AppRouter() {
     isOzAuthenticated,
     location.pathname,
     location.search,
-    pendingIdt, // ✅ 의존성에 포함
+    pendingIdt,
     goto,
   ]);
 
-  // 훅 호출 이후에 조기 return (로딩 스켈레톤)
   if (loading) return <div className="p-6">Loading...</div>;
 
   return (
     <Routes>
-      {/* 전역 레이아웃(ToastContainer 포함) */}
       <Route element={<RootLayout />}>
-        {/* 테스트 라우트 */}
-        <Route path={PATHS.ROOT} element={<TestHub />} />
-        <Route path="/test/write" element={<TestPostWritePage />} />
-        <Route path="/test/tag" element={<TestTagPage />} />
-        <Route path="/test/post" element={<TestPostReadPage />} />
-        <Route path="/test/setting" element={<TestSettingPage />} />
-        <Route path="/test/board/free-list" element={<TestFreeBoardList />} />
-        <Route path="/test/board/survey-list" element={<TestSurveyList />} />
-        <Route path="/test/board/github-list" element={<TestGithubList />} />
-        <Route path="/test/jobbanner" element={<TestJobBannerPage />} />
+        {/* 루트 접근 시 상태 기반으로 분기 */}
+        <Route
+          path={PATHS.ROOT}
+          element={
+            isAuthed ? (
+              isOzAuthenticated ? (
+                <Navigate to={PATHS.MAIN} replace />
+              ) : (
+                <Navigate to={PATHS.KEY_VERIFY} replace />
+              )
+            ) : (
+              <Navigate to={PATHS.AUTH} replace />
+            )
+          }
+        />
 
-        {/* API 테스트 라우트 */}
-        <Route path="/boards/free" element={<PostListPage board="free" />} />
-        <Route path="/boards/jobs" element={<PostListPage board="jobs" />} />
-        <Route path="/boards/info" element={<PostListPage board="info" />} />
-        <Route path="/boards/survey" element={<SurveyListPage />} />
-        <Route path="/boards/github" element={<GithubListPage />} />
-
-        {/* 인증 로비(공개) */}
+        {/* 공개: /auth */}
         <Route path={PATHS.AUTH} element={<LandingPage />} />
 
-        {/* 보호: /key-verify (JWT + 미인증) */}
+        {/* 보호: /key-verify → SettingsPage로 교체 */}
         <Route
           path={PATHS.KEY_VERIFY}
           element={
             (isAuthed && isOzAuthenticated === false) || pendingIdt ? (
-              <KeyVerifyPlaceholder />
+              <KeyVerifySettingsPage />
             ) : isAuthed && isOzAuthenticated === true ? (
               <Navigate to={PATHS.MAIN} replace />
             ) : (
@@ -272,7 +168,7 @@ export default function AppRouter() {
           }
         />
 
-        {/* 메인 페이지 + 게시글 + 마이페이지 */}
+        {/* 메인 + 게시판 + 마이페이지 */}
         <Route element={<MainLayout />}>
           <Route path={PATHS.MAIN} element={<MainPage />} />
           <Route
@@ -292,7 +188,7 @@ export default function AppRouter() {
           <Route path={PATHS.POST_DETAIL} element={<PostDetailPage />} />
           <Route path={PATHS.POST_CREATE} element={<WritePostPage />} />
 
-          {/* 보호: 마이페이지 (JWT + 인증 완료) */}
+          {/* 보호: 마이페이지 */}
           <Route
             path={PATHS.MYPAGE}
             element={
@@ -305,7 +201,6 @@ export default function AppRouter() {
               )
             }
           >
-            {/* 마이페이지 중첩 라우팅 */}
             <Route index element={<MyPageMain />} />
             <Route path={PATHS.MYPAGE_POSTS} element={<MyPosts />} />
             <Route path={PATHS.MYPAGE_COMMENTS} element={<MyComments />} />


### PR DESCRIPTION
테스트 허브 컴포넌트는 남기되, 라우트는 삭제하여 접근할 수 없도록 했습니다.
추가로 키 인증 가능한 설정 팝업에 ozkey 인증 API 로직 연결 안 되어 있어서 연결했습니다.

- 테스트 라우트 삭제
- 미인증 사용자 라우트는 SettingsPage로
- SettingsPage 쪽에 ozkey 인증 로직 추가
- 루트 경로를 가입/인증여부 분기로 변경

현재 로컬에서 키 인증 시 400 에러가 발생하는데, 확인 부탁드립니다.

---

closes #222 