### PR TITLE
[design] 공통 CSS 수정

### DIFF
--- a/src/components/Board/SurveyPostForm.tsx
+++ b/src/components/Board/SurveyPostForm.tsx
@@ -204,7 +204,7 @@ export default function SurveyPostForm({
       {/* 설문지 작성 / 링크 / 마감일 */}
       <div className="flex flex-wrap gap-4">
         <div className="flex flex-col gap-1 shrink-0">
-          <label className="font-semibold text-white">설문 생성</label>
+          <label className="font-semibold text-base-content">설문 생성</label>
           <select
             aria-label="설문 폼 선택"
             className="border border-gray-300 rounded p-2 bg-white shrink-0"
@@ -224,7 +224,10 @@ export default function SurveyPostForm({
 
         {/* 설문 링크 입력 */}
         <div className="flex flex-col gap-1 flex-1 min-w-[220px]">
-          <label htmlFor="survey-link" className="font-semibold text-white">
+          <label
+            htmlFor="survey-link"
+            className="font-semibold text-base-content"
+          >
             설문 링크
           </label>
           <input
@@ -242,7 +245,10 @@ export default function SurveyPostForm({
 
         {/* 설문 마감일 */}
         <div className="flex flex-col gap-1 shrink-0">
-          <label htmlFor="survey-end" className="font-semibold text-white">
+          <label
+            htmlFor="survey-end"
+            className="font-semibold text-base-content"
+          >
             마감일
           </label>
           <input
@@ -287,8 +293,8 @@ export default function SurveyPostForm({
               ? "수정 중..."
               : "작성 중..."
             : isEdit
-            ? "수정"
-            : "작성"}
+              ? "수정"
+              : "작성"}
         </Button>
       </div>
       <ConfirmModal

--- a/src/components/Board/WritePostPage.tsx
+++ b/src/components/Board/WritePostPage.tsx
@@ -44,7 +44,7 @@ const WritePostPage = () => {
   };
 
   return (
-    <div className="flex flex-col w-full h-full gap-2 text-black">
+    <div className="flex flex-col w-full h-full gap-2 text-black mb-8">
       {/* 1. 게시판 선택 */}
       <div>
         <select

--- a/src/components/Board/common/tagfilter/PositionRadio.tsx
+++ b/src/components/Board/common/tagfilter/PositionRadio.tsx
@@ -22,9 +22,9 @@ export default function PositionRadio({
     () =>
       options ?? [
         { value: "front", label: "프론트엔드" },
-        { value: "startup", label: "창업" },
+        { value: "startup", label: "창업", disabled: true },
         { value: "back", label: "백엔드" },
-        { value: "design", label: "디자인" },
+        { value: "design", label: "디자인", disabled: true },
       ],
     [options]
   );

--- a/src/components/Post/PostDetail.tsx
+++ b/src/components/Post/PostDetail.tsx
@@ -399,7 +399,7 @@ export default function PostDetail({
             취소
           </button>
           <button
-            className="btn btn-primary btn-sm"
+            className="btn btn-primary btn-sm text-white"
             onClick={submitComment}
             disabled={submitting || !commentDraft.trim()}
             type="button"

--- a/src/components/commons/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/commons/ConfirmModal/ConfirmModal.tsx
@@ -53,17 +53,17 @@ export default function ConfirmModal({
       onClick={handleClickOutside}
     >
       <div
-        className="bg-primary-content rounded-2xl shadow-2xl w-full max-w-md mx-auto z-[4000] animate-in fade-in-0 zoom-in-95 duration-200"
+        className="bg-accent-content rounded-2xl shadow-2xl w-full max-w-md mx-auto z-[4000] animate-in fade-in-0 zoom-in-95 duration-200"
         onClick={(e) => e.stopPropagation()}
       >
         {/* 모달 내용 */}
         <div className="p-6 text-center">
-          <h2 className="text-lg font-semibold text-accent-content mb-3 leading-relaxed break-keep">
+          <h2 className="text-lg font-semibold text-primary-content mb-3 leading-relaxed break-keep">
             {title}
           </h2>
 
           {description && (
-            <p className="text-sm text-gray-700 mb-6 leading-relaxed break-keep whitespace-pre-wrap">
+            <p className="text-sm text-[#8e8e8e] mb-6 leading-relaxed break-keep whitespace-pre-wrap">
               {description}
             </p>
           )}
@@ -73,7 +73,7 @@ export default function ConfirmModal({
             <button
               type="button"
               onClick={onCancel}
-              className="flex-1 px-4 py-3 rounded-xl outline-none border border-accent-content bg-transparent text-accent-content font-medium hover:bg-accent-content hover:border-transparent hover:text-primary-content focus:ring-2 focus:ring-primary/20 transition-colors duration-200"
+              className="flex-1 px-4 py-3 rounded-xl outline-none border border-base-content bg-transparent text-base-content  font-medium hover:bg-base-content hover:border-transparent hover:text-accent-content focus:ring-2 focus:ring-primary/20 transition-colors duration-200"
             >
               {cancelLabel}
             </button>
@@ -81,7 +81,7 @@ export default function ConfirmModal({
             <button
               type="button"
               onClick={onConfirm}
-              className="flex-1 px-4 py-3 rounded-xl outline-none bg-primary text-primary-content font-medium hover:bg-secondary focus:ring-2 focus:ring-primary/20 transition-colors duration-200"
+              className="flex-1 px-4 py-3 rounded-xl outline-none bg-primary text-[#f5f5f5] font-medium hover:bg-secondary focus:ring-2 focus:ring-primary/20 transition-colors duration-200"
             >
               {confirmLabel}
             </button>

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -45,7 +45,7 @@ export default function LandingPage() {
     } catch (e: unknown) {
       const msg =
         typeof e === "object" && e && "message" in e
-          ? (e as { message?: string }).message ?? "로그인 실패"
+          ? ((e as { message?: string }).message ?? "로그인 실패")
           : "로그인 실패";
       push({ message: msg, type: "error" });
     }
@@ -63,7 +63,7 @@ export default function LandingPage() {
         type="button"
         onClick={onClickGoogle}
         disabled={disabled}
-        className="btn btn-primary w-60"
+        className="btn btn-primary text-white w-60"
       >
         {disabled && <span className="loading loading-spinner"></span>}
         {disabled ? "처리 중..." : "Continue with Google"}

--- a/src/utils/google.ts
+++ b/src/utils/google.ts
@@ -45,7 +45,7 @@ function mountOverlay(): {
 
   const card = document.createElement("div");
   Object.assign(card.style, {
-    background: "white",
+    background: "#F5F5F5",
     padding: "24px",
     borderRadius: "12px",
     minWidth: "320px",
@@ -55,7 +55,12 @@ function mountOverlay(): {
 
   const title = document.createElement("div");
   title.textContent = "Google 계정으로 계속하기";
-  Object.assign(title.style, { fontSize: "16px", marginBottom: "12px" });
+  Object.assign(title.style, {
+    color: "#1A1A1A",
+    fontSize: "16px",
+    fontWeight: "medium",
+    marginBottom: "12px",
+  });
 
   const btnHost = document.createElement("div");
   btnHost.id = "google_btn_host";


### PR DESCRIPTION
하나 고치다보니 다른 것들도 손 보게 되어서,
이왕 이렇게 된 거 여기저기 테마에 맞추고 디자인 변경했습니다.

### 랜딩페이지 버튼 텍스트 컬러 white 고정
- 라이트 테마에서 검정이 됐었는데, 어색해서 white로 통일

<img width="394" height="205" alt="image" src="https://github.com/user-attachments/assets/f9c2427f-924a-4676-983f-488d60d73424" />


### 컨펌모달 테마 색 반전
- 테마 컬러 맞춤

<img width="594" height="259" alt="image" src="https://github.com/user-attachments/assets/96e3d96e-336c-4733-9040-5dad8995807f" />
<img width="593" height="265" alt="image" src="https://github.com/user-attachments/assets/f8881790-175c-4e66-a595-7e711e5b1dae" />


### google 로그인 card 폰트 컬러와 배경색 조정
- 폰트 컬러가 배경색과 비슷한 화이트 톤이어서 잘 안 보였기에 블랙 톤으로 변경

<img width="386" height="194" alt="image" src="https://github.com/user-attachments/assets/6ce2f02d-c3b4-477e-8ab8-a72b04bda9b9" />

### 댓글 작성 버튼 텍스트 컬러 white 고정
- 라이트 테마에서 검정이 됐었는데, 어색해서 white로 통일

<img width="199" height="91" alt="image" src="https://github.com/user-attachments/assets/f7cd4eac-b3ee-4dbc-8eff-c9c33c3639af" />

### 필터 모달에서 창업과 디자인은 선택 불가하게 disable
- 창업, 디자인은 서버에 쿼리로 넘어가지 아니하고 기능이 없으므로 아예 disable 처리

<img width="374" height="391" alt="image" src="https://github.com/user-attachments/assets/29434c6a-9b39-4b61-958a-fdf739d8391f" />

### 설문 게시글 작성 페이지에서 설문 생성, 링크, 마감일 텍스트 컬러 테마 맞춤
- 기존엔 라이트 모드에서 글씨가 잘 안 보였어서 변경

<img width="864" height="279" alt="image" src="https://github.com/user-attachments/assets/fb2bcab2-844e-4e1f-b28e-858fb928440e" />

### 게시글 작성 페이지 margin bottom 추가
- 아래가 너무 밭아서 여백 추가

<img width="852" height="87" alt="image" src="https://github.com/user-attachments/assets/9fd37006-7ca9-4ea4-aa32-5f18732c6380" />

---

closes #37 