### PR TITLE
[fix] Hot 게시물 정보, 취업 게시판 이름 수정

### DIFF
--- a/src/components/HotBoard/HotPostCard.tsx
+++ b/src/components/HotBoard/HotPostCard.tsx
@@ -23,8 +23,8 @@ export default function HotPostCard({
   }, [themeIcon]);
   const BOARD_NAME_MAP: Record<number, string> = {
     1: "자유",
-    2: "취업",
-    3: "정보",
+    2: "정보",
+    3: "취업",
     4: "설문",
     5: "GitHub",
   };

--- a/src/components/HotBoard/boardColor.ts
+++ b/src/components/HotBoard/boardColor.ts
@@ -1,15 +1,15 @@
 export const CARD_STYLE: Record<string, string> = {
   1: "border-pink-500/30 bg-pink-500/5 hover:border-pink-500/70 hover:bg-pink-500/10",
-  2: "border-green-500/30 bg-green-500/5 hover:border-green-500/70 hover:bg-green-500/10",
-  3: "border-amber-500/30 bg-amber-500/5 hover:border-amber-500/70 hover:bg-amber-500/10",
+  2: "border-amber-500/30 bg-amber-500/5 hover:border-amber-500/70 hover:bg-amber-500/10",
+  3: "border-green-500/30 bg-green-500/5 hover:border-green-500/70 hover:bg-green-500/10",
   4: "border-blue-500/30 bg-blue-500/5 hover:border-blue-500/70 hover:bg-blue-500/10",
   5: "border-purple-500/30 bg-purple-500/5 hover:border-purple-500/70 hover:bg-purple-500/10",
 };
 
 export const CARD_TEXT: Record<string, string> = {
   1: "text-pink-500/70",
-  2: "text-green-500/70",
-  3: "text-amber-500/70",
+  2: "text-amber-500/70",
+  3: "text-green-500/70",
   4: "text-blue-500/70",
   5: "text-purple-500/70",
 };


### PR DESCRIPTION
Hot 게시물 정보 게시판과 취업 게시판 이름이 뒤바뀌어 수정했습니다. + 컬러
<img width="448" height="228" alt="image" src="https://github.com/user-attachments/assets/7fc3be37-7061-432f-9027-d2d592635088" />
closes #241 